### PR TITLE
ci(release): fix upload

### DIFF
--- a/.github/actions/reusable-release-action/action.yml
+++ b/.github/actions/reusable-release-action/action.yml
@@ -17,10 +17,6 @@ inputs:
     description: 'Create as draft'
     required: false
     default: 'false'
-  arch:
-    description: 'Package type to release (rpm or deb)'
-    required: false
-    default: 'all'
 
 runs:
   using: "composite"
@@ -122,8 +118,8 @@ runs:
 
           For complete documentation, visit: https://github.com/pmpetit/pglinter/blob/main/docs/functions/README.md
         files: |
-          ${{ (inputs.arch == 'rpm' && './artifacts/*.rpm') || (inputs.arch == 'deb' && './artifacts/*.deb') || (inputs.arch == 'all' && './artifacts/*.rpm\n./artifacts/*.deb') }}
-
+          ./artifacts/*.rpm
+          ./artifacts/*.deb
 
     - name: List release assets
       run: |


### PR DESCRIPTION
This pull request simplifies the release workflow configuration in `.github/actions/reusable-release-action/action.yml` by removing the `arch` input and its associated logic. Now, both RPM and DEB artifacts are always included in the release, streamlining the process and reducing complexity.

Workflow configuration simplification:

* Removed the `arch` input parameter and its description from the action inputs, so users no longer need to specify which package type to release.
* Updated the files list in the release step to always include both `./artifacts/*.rpm` and `./artifacts/*.deb`, instead of conditionally selecting files based on the `arch` input.