### PR TITLE
doc(tutorial): add a link to tutorial to create rules 

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,32 +187,7 @@ SELECT pglinter.import_rules_from_yaml('yaml...');   -- Import rules from YAML
 
 ## Rule Implementation
 
-Adding a new rule is straightforward:
-
-```rust
-pub struct B007Rule; // New rule
-
-impl DatabaseRule for B007Rule {
-    fn execute(&self, params: &[RuleParam]) -> spi::Result<Option<RuleResult>> {
-        // Your rule logic here
-        let query = "SELECT count(*) FROM problematic_tables";
-
-        let result = Spi::connect(|client| {
-            // Execute query and analyze results
-            // Return RuleResult if issues found
-        })?;
-
-        Ok(result)
-    }
-
-    fn rule_id(&self) -> &str { "B007" }
-    fn scope(&self) -> RuleScope { RuleScope::Base }
-    fn name(&self) -> &str { "YourRuleName" }
-}
-
-// Register in RuleEngine::new()
-rules.insert("B007".to_string(), Box::new(B007Rule));
-```
+Adding a new rule is straightforward. For a comprehensive step-by-step guide, see the [How to Create Rules Tutorial](https://pglinter.readthedocs.io/en/latest/tutorial/how_to_create_rules/) in the documentation.
 
 ## SARIF Output
 


### PR DESCRIPTION
This pull request updates the guidance for adding new rules in the `README.md` to improve maintainability and keep documentation consistent. Instead of including an inline Rust code example, contributors are now directed to a dedicated tutorial in the documentation.

Documentation improvements:

* Replaced the inline Rust example for adding a new rule with a reference to the official "How to Create Rules Tutorial" in the documentation, making it easier to maintain and ensuring users always have access to the most up-to-date instructions.