### PR TITLE
docs(remove t-rules): update docs on t-rules

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -28,7 +28,7 @@ SELECT pglinter.enable_rule('B001');
 
 -- Disable multiple rules
 SELECT pglinter.disable_rule('B004');
-SELECT pglinter.disable_rule('T007');
+
 ```
 
 ### Rules Categories
@@ -41,10 +41,7 @@ SELECT pglinter.disable_rule(rule_code)
 FROM pglinter.show_rules()
 WHERE rule_code LIKE 'B%';
 
--- Enable only base/database rules (including table checks)
-SELECT pglinter.enable_rule(rule_code)
-FROM pglinter.show_rules()
-WHERE rule_code LIKE 'B%';
+
 ```
 
 ### Export/Import Rules

--- a/sql/rules.sql
+++ b/sql/rules.sql
@@ -10,7 +10,6 @@
 --   B-series: Base Database Rules (tables, indexes, primary keys, etc.)
 --   C-series: Cluster Rules (configuration, security, performance)
 --   S-series: Schema Rules (permissions, ownership, security)
---   T-series: Table Rules (specific table-level analysis)
 --
 -- Each rule includes:
 --   - Rule code (e.g., B001, T003)


### PR DESCRIPTION
This pull request updates documentation and comments to clarify rule categories and usage in the linter configuration. The main changes focus on improving clarity regarding rule series and streamlining example queries.

Documentation improvements:

* Removed the example query for enabling only base/database rules in `docs/configure.md` to simplify documentation and avoid redundancy.
* Removed the example for disabling the `T007` rule in `docs/configure.md`, likely for consistency or because it's no longer relevant.

Comment clarification:

* Removed the description for the T-series (Table Rules) in the rule series comment block in `sql/rules.sql` to clarify the available rule categories.