### PR TITLE
feat(new rule): add rule b013, row by row processing trigger without where clause

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pglinter"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 
 [lib]

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ REGRESS_TESTS+= b010_reserved_keywords
 REGRESS_TESTS+= b011_several_table_owner_in_schema
 REGRESS_TESTS+= b012_composite_pk
 REGRESS_TESTS+= b013_trigger_row_by_row
+REGRESS_TESTS+= b013_trigger_row_by_row_with_clause
 REGRESS_TESTS+= s001_schema_with_default_role_not_granted
 REGRESS_TESTS+= s002_schema_prefixed_or_suffixed_with_envt
 REGRESS_TESTS+= s003_public_schema

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ REGRESS_TESTS+= b009_trigger_sharing
 REGRESS_TESTS+= b010_reserved_keywords
 REGRESS_TESTS+= b011_several_table_owner_in_schema
 REGRESS_TESTS+= b012_composite_pk
+REGRESS_TESTS+= b013_trigger_row_by_row
 REGRESS_TESTS+= s001_schema_with_default_role_not_granted
 REGRESS_TESTS+= s002_schema_prefixed_or_suffixed_with_envt
 REGRESS_TESTS+= s003_public_schema

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -465,6 +465,61 @@ HAVING COUNT(kcu.column_name) > 4;
 
 ---
 
+### B013: Trigger Functions With Unbounded Cursor (No WHERE Clause)
+
+**Rule Code**: B013
+**Name**: HowManyTablesWithRowByRowTriggerWithoutWhereClause
+**Severity**: Warning at 20%, Error at 80%
+**Scope**: BASE
+
+**Description**: Count number of tables using a row by row processing without any WHERE clause vs nb table with their own triggers.
+
+**Message Template**: `{0}/{1} table(s) using row by row processing without any WHERE clause exceed the {2} threshold: {3}%. Object list:\n{4}`
+
+**Why This Matters**:
+
+- A trigger function that opens a cursor (or uses a `FOR rec IN SELECT ... LOOP`) without a `WHERE` clause will scan the entire table on every triggered row
+- This turns a single DML statement into a potentially massive, unbounded table scan
+- Can cause severe performance degradation on large tables, turning fast operations into multi-second or multi-minute waits
+- Leads to lock contention and timeout cascades in concurrent workloads
+
+**How to Fix**:
+
+- Prefer set-based operations over row-by-row cursor processing in trigger functions
+- If a cursor is necessary, add a `WHERE` clause to limit the rows returned to only those relevant to the triggering row (e.g. filter on the primary key or a foreign key matching `NEW.id`)
+
+**SQL Example**:
+
+```sql
+-- Bad: trigger function with unbounded cursor
+CREATE OR REPLACE FUNCTION audit_all_rows()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+    rec RECORD;
+BEGIN
+    FOR rec IN SELECT * FROM orders LOOP  -- no WHERE clause: full table scan on every trigger fire
+        -- process rec
+    END LOOP;
+    RETURN NEW;
+END;
+$$;
+
+-- Good: cursor limited to the affected row only
+CREATE OR REPLACE FUNCTION audit_related_rows()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+    rec RECORD;
+BEGIN
+    FOR rec IN SELECT * FROM orders WHERE customer_id = NEW.customer_id LOOP
+        -- process only relevant rows
+    END LOOP;
+    RETURN NEW;
+END;
+$$;
+```
+
+---
+
 ## Schema Rules (S-series)
 
 Schema-level checks for functional namespace.
@@ -510,7 +565,7 @@ GRANT SELECT ON TABLES TO myschema_ro;
 **Severity**: Warning at 1, Error at 1
 **Scope**: SCHEMA
 
-**Description**: The schema is prefixed with one of staging,stg,preprod,prod,sandbox,sbox string. Means that when you refresh your preprod, staging environments from production, you have to rename the target schema from prod_ to stg_ or something like. It is possible, but it is never easy.
+**Description**: The schema is prefixed with one of staging,stg,preprod,prod,sandbox,sbox string. Means that when you refresh your preprod, staging environments from production, you have to rename the target schema from prod_to stg_ or something like. It is possible, but it is never easy.
 
 **Message Template**: `You should not prefix or suffix the schema name with {0}. You may have difficulties when refreshing environments. Prefer prefix or suffix the database name.`
 

--- a/sql/rules.sql
+++ b/sql/rules.sql
@@ -148,7 +148,11 @@ INSERT INTO pglinter.rules (
     ]
 ),
 (
-    'HowManyTablesWithRowByRowTriggerWithoutWhereClause', 'B013', 20, 80, 'BASE',
+    'HowManyTablesWithRowByRowTriggerWithoutWhereClause',
+    'B013',
+    20,
+    80,
+    'BASE',
     'Count number of tables using a row by row processing without any where clause vs nb table with their own triggers.',
     '{0}/{1} table(s) using row by row processing without any where clause exceed the {2} threshold: {3}%. Object list:\n{4}',
     ARRAY[
@@ -189,7 +193,9 @@ INSERT INTO pglinter.rules (
     'SchemaOwnerDoNotMatchTableOwner', 'S005', 20, 80, 'SCHEMA',
     'The schema owner and tables in the schema do not match.',
     '{0}/{1} in the same schema, tables have different owners. They should be the same. Exceed the {2} threshold: {3}%. Object list:\n{4}',
-    ARRAY['For maintenance facilities, schema and tables owners should be the same.']
+    ARRAY[
+        'For maintenance facilities, schema and tables owners should be the same.'
+    ]
 ),
 (
     'PgHbaEntriesWithMethodTrustShouldNotExists',
@@ -219,7 +225,9 @@ INSERT INTO pglinter.rules (
     'CLUSTER',
     'This configuration is not secure anymore and will prevent an upgrade to Postgres 18. Warning, you will need to reset all passwords after this is changed to scram-sha-256.',
     'Encrypted passwords with MD5.',
-    ARRAY['change password_encryption parameter to scram-sha-256 (ALTER SYSTEM SET password_encryption = ''scram-sha-256'' ). Warning, you will need to reset all passwords after this parameter is updated.']
+    ARRAY[
+        'change password_encryption parameter to scram-sha-256 (ALTER SYSTEM SET password_encryption = ''scram-sha-256'' ). Warning, you will need to reset all passwords after this parameter is updated.'
+    ]
 );
 
 
@@ -279,7 +287,7 @@ WHERE
     )
 ORDER BY 1
 $$,
-  q4 = $$
+    q4 = $$
 -- Returns classid, objid, objsubid for tables without a primary key
 SELECT
     'pg_class'::regclass::oid AS classid,
@@ -389,7 +397,7 @@ WHERE
 
 ORDER BY 1, 2
 $$,
-  q4 = $$
+    q4 = $$
 WITH index_info AS (
     SELECT
         ind.indrelid AS table_oid,
@@ -922,7 +930,7 @@ ORDER BY
     schema_name,
     object_name
 $$,
-  q4 = $$
+    q4 = $$
 -- Returns classid, objid, objsubid for objects with uppercase in their name
 SELECT 'pg_class'::regclass::oid AS classid, c.oid AS objid, 0 AS objsubid
 FROM pg_class c
@@ -986,7 +994,7 @@ WHERE code = 'B005';
 -- =============================================================================
 UPDATE pglinter.rules
 SET
-  q1 = $$
+    q1 = $$
 SELECT count(*)::BIGINT
 FROM pg_catalog.pg_tables pt
 WHERE
@@ -994,7 +1002,7 @@ WHERE
         'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
     )
 $$,
-  q2 = $$
+    q2 = $$
 SELECT COUNT(*) AS unselected_tables
 FROM pg_stat_user_tables AS psu
 WHERE
@@ -1007,7 +1015,7 @@ WHERE
         'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
     )
 $$,
-  q3 = $$
+    q3 = $$
 SELECT psu.schemaname::text, psu.relname::text
 FROM pg_stat_user_tables AS psu
 WHERE
@@ -1020,7 +1028,7 @@ WHERE
         'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
     )
 $$,
-  q4 = $$
+    q4 = $$
 SELECT
     'pg_class'::regclass::oid AS classid,
     c.oid AS objid,
@@ -1092,7 +1100,7 @@ WHERE
         'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
     )
 $$,
-  q4 = $$
+    q4 = $$
 SELECT
     'pg_constraint'::regclass::oid AS classid,
     c.oid AS objid,
@@ -1196,7 +1204,7 @@ WHERE
     )
     AND col1.data_type != col2.data_type
 $$,
-  q4 = $$
+    q4 = $$
 SELECT
     'pg_attribute'::regclass::oid AS classid,
     c.oid AS objid,
@@ -1234,7 +1242,8 @@ WHERE code = 'B008';
 -- B009 - Tables With same trigger
 -- =============================================================================
 UPDATE pglinter.rules
-SET q1 = $$
+SET
+    q1 = $$
 SELECT
     COALESCE(COUNT(DISTINCT event_object_table), 0)::BIGINT as table_using_trigger
 FROM
@@ -1244,7 +1253,7 @@ WHERE
     'pg_toast', 'pg_catalog', 'information_schema', 'pglinter'
 )
 $$,
-  q2 = $$
+    q2 = $$
 SELECT
     COALESCE(SUM(shared_table_count), 0)::BIGINT AS table_using_same_trigger
 FROM (
@@ -1268,7 +1277,7 @@ FROM (
         COUNT(DISTINCT t.event_object_table) > 1
 ) shared_triggers
 $$,
-  q3 = $$
+    q3 = $$
 WITH SharedFunctions AS (
     -- 1. Identify all trigger functions that are used by more than one table
     SELECT
@@ -1302,7 +1311,7 @@ ORDER BY
     t.trigger_schema,
     t.event_object_table
 $$,
-  q4 = $$
+    q4 = $$
 -- Returns classid, objid, objsubid for tables using the same trigger function (B009)
 WITH SharedFunctions AS (
     SELECT
@@ -1343,7 +1352,8 @@ WHERE code = 'B009';
 -- B010 - Tables With Reserved Keywords
 -- =============================================================================
 UPDATE pglinter.rules
-  SET q1 = $$
+SET
+    q1 = $$
 SELECT count(*)::BIGINT AS total_tables
 FROM pg_catalog.pg_tables
 WHERE
@@ -1351,7 +1361,7 @@ WHERE
         'pg_toast', 'pg_catalog', 'information_schema', 'pglinter','_timescaledb', 'timescaledb'
     )
 $$,
-  q2 = $$
+    q2 = $$
 WITH reserved_keywords AS (
     SELECT UNNEST(ARRAY[
         'ALL', 'ANALYSE', 'ANALYZE', 'AND', 'ANY', 'ARRAY', 'AS', 'ASC',
@@ -1419,7 +1429,7 @@ FROM (
         AND UPPER(indexname) = keyword
 ) reserved_objects
 $$,
-  q3 = $$
+    q3 = $$
 WITH reserved_keywords AS (
     SELECT UNNEST(ARRAY[
         'ALL', 'ANALYSE', 'ANALYZE', 'AND', 'ANY', 'ARRAY', 'AS', 'ASC',
@@ -1497,7 +1507,7 @@ ORDER BY
     schema_name,
     object_name
 $$,
-  q4 = $$
+    q4 = $$
 WITH reserved_keywords AS (
     SELECT unnest(ARRAY[
         'SELECT','FROM','WHERE','ORDER','GROUP','HAVING','UNION','JOIN','LIMIT','OFFSET',
@@ -1786,7 +1796,8 @@ WHERE code = 'B012';
 -- B013 - Tables With row by row processing without any where clause
 -- =============================================================================
 UPDATE pglinter.rules
-SET q1 = $$
+SET
+    q1 = $$
 SELECT
     COALESCE(COUNT(DISTINCT event_object_table), 0)::BIGINT as table_using_trigger
 FROM
@@ -1796,7 +1807,7 @@ WHERE
     'pg_toast', 'pg_catalog', 'information_schema', 'pglinter'
 )
 $$,
-  q2 = $$
+    q2 = $$
 SELECT
     COUNT(DISTINCT c.oid)::BIGINT AS tables_with_unbounded_cursor_trigger
 FROM pg_trigger tg
@@ -1811,16 +1822,18 @@ WHERE
     )
     -- function body has a cursor/FOR-loop SELECT ...
     AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
-    -- but none of those SELECT blocks contain a WHERE keyword
-    AND NOT (
-        (regexp_matches(
+    -- at least one of those SELECT blocks has no WHERE clause
+    AND EXISTS (
+        SELECT 1
+        FROM regexp_matches(
             p.prosrc,
             '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
             'gix'
-        ))[1] ~* '\mWHERE\M'
+        ) AS m(cursor_select)
+        WHERE m.cursor_select[1] !~* '\mWHERE\M'
     )
 $$,
-  q3 = $$
+    q3 = $$
 SELECT
     n.nspname::TEXT                          AS schema_name,
     c.relname::TEXT                          AS table_name,
@@ -1839,16 +1852,18 @@ WHERE
         'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
     )
     AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
-    AND NOT (
-        (regexp_matches(
+    AND EXISTS (
+        SELECT 1
+        FROM regexp_matches(
             p.prosrc,
             '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
             'gix'
-        ))[1] ~* '\mWHERE\M'
+        ) AS m(cursor_select)
+        WHERE m.cursor_select[1] !~* '\mWHERE\M'
     )
 ORDER BY n.nspname, c.relname, tg.tgname
 $$,
-  q4 = $$
+    q4 = $$
 SELECT
     'pg_trigger'::regclass::oid AS classid,
     tg.oid                      AS objid,
@@ -1864,16 +1879,17 @@ WHERE
         'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
     )
     AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
-    AND NOT (
-        (regexp_matches(
+    AND EXISTS (
+        SELECT 1
+        FROM regexp_matches(
             p.prosrc,
             '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
             'gix'
-        ))[1] ~* '\mWHERE\M'
+        ) AS m(cursor_select)
+        WHERE m.cursor_select[1] !~* '\mWHERE\M'
     )
 $$
 WHERE code = 'B013';
-
 
 
 -- =============================================================================
@@ -1920,7 +1936,7 @@ WHERE
     )
 ORDER BY 1
 $$,
-  q4 = $$
+    q4 = $$
 -- Returns classid, objid, objsubid for schemas with no default role (S001)
 SELECT
     'pg_namespace'::regclass::oid AS classid,
@@ -2159,7 +2175,7 @@ WHERE
     AND n.nspowner <> c.relowner      -- The core condition: Owners are different
 ORDER BY 1
 $$,
-  q4 = $$
+    q4 = $$
 -- Returns classid, objid, objsubid for tables where the schema owner and table owner differ (S005)
 SELECT
     'pg_class'::regclass::oid AS classid,
@@ -2228,29 +2244,83 @@ WHERE code = 'C003';
 CREATE TABLE IF NOT EXISTS pglinter.rule_messages (
     id SERIAL PRIMARY KEY,
     code TEXT,
-    rule_msg jsonb
+    rule_msg JSONB
 );
 
 DELETE FROM pglinter.rule_messages;
 
 INSERT INTO pglinter.rule_messages (code, rule_msg) VALUES
-('S001', '{"severity": "WARNING", "message": "Schema {object} has no default role.", "advices": "Add a default privilege to the schema so future tables are granted to a role automatically.", "infos": ["How to fix: ALTER DEFAULT PRIVILEGES IN SCHEMA {object} FOR USER <owner> GRANT ...;"]}'),
-('S002', '{"severity": "WARNING", "message": "Schema {object} is prefixed or suffixed with an environment name.", "advices": "Keep the same schema name across environments. Prefer prefixing or suffixing the database name instead.", "infos": ["How to fix: Rename schema {object} to a neutral name."]}'),
-('S003', '{"severity": "WARNING", "message": "Schema {object} is unsecured: PUBLIC can create objects.", "advices": "REVOKE CREATE ON SCHEMA from PUBLIC to restrict object creation.", "infos": ["How to fix: REVOKE CREATE ON SCHEMA {object} FROM PUBLIC;"]}'),
-('S004', '{"severity": "WARNING", "message": "Schema {object} is owned by an internal role or superuser.", "advices": "Change schema owner to a functional role for better security and maintainability.", "infos": ["How to fix: ALTER SCHEMA {object} OWNER TO <role>;"]}'),
-('S005', '{"severity": "WARNING", "message": "Schema {object} and its tables have different owners.", "advices": "For easier maintenance, schema and tables should have the same owner.", "infos": ["How to fix: ALTER TABLE {object} OWNER TO <role>;"]}');
+(
+    'S001',
+    '{"severity": "WARNING", "message": "Schema {object} has no default role.", "advices": "Add a default privilege to the schema so future tables are granted to a role automatically.", "infos": ["How to fix: ALTER DEFAULT PRIVILEGES IN SCHEMA {object} FOR USER <owner> GRANT ...;"]}'
+),
+(
+    'S002',
+    '{"severity": "WARNING", "message": "Schema {object} is prefixed or suffixed with an environment name.", "advices": "Keep the same schema name across environments. Prefer prefixing or suffixing the database name instead.", "infos": ["How to fix: Rename schema {object} to a neutral name."]}'
+),
+(
+    'S003',
+    '{"severity": "WARNING", "message": "Schema {object} is unsecured: PUBLIC can create objects.", "advices": "REVOKE CREATE ON SCHEMA from PUBLIC to restrict object creation.", "infos": ["How to fix: REVOKE CREATE ON SCHEMA {object} FROM PUBLIC;"]}'
+),
+(
+    'S004',
+    '{"severity": "WARNING", "message": "Schema {object} is owned by an internal role or superuser.", "advices": "Change schema owner to a functional role for better security and maintainability.", "infos": ["How to fix: ALTER SCHEMA {object} OWNER TO <role>;"]}'
+),
+(
+    'S005',
+    '{"severity": "WARNING", "message": "Schema {object} and its tables have different owners.", "advices": "For easier maintenance, schema and tables should have the same owner.", "infos": ["How to fix: ALTER TABLE {object} OWNER TO <role>;"]}'
+);
 
 INSERT INTO pglinter.rule_messages (code, rule_msg) VALUES
-('B001', '{"severity": "WARNING", "message": "{object} does not have a primary key.", "advices": "Add a primary key to this table to ensure data integrity and better performance.", "infos": ["How to fix: ALTER TABLE {object} ADD PRIMARY KEY (...);"]}'),
-('B002', '{"severity": "WARNING", "message": "{object} is a redundant index.", "advices": "Remove redundant or duplicate indexes to optimize performance and storage.", "infos": ["How to fix: DROP INDEX {object}; or review constraints that may create duplicate indexes."]}'),
-('B003', '{"severity": "WARNING", "message": "{object} does not have an index on its foreign key.", "advices": "Create an index on the foreign key column to improve join and lookup performance.", "infos": ["How to fix: CREATE INDEX ON {object} (...);"]}'),
-('B004', '{"severity": "WARNING", "message": "{object} is an unused index.", "advices": "Remove unused indexes to reduce storage and maintenance overhead.", "infos": ["How to fix: DROP INDEX {object}; or review index usage statistics."]}'),
-('B005', '{"severity": "WARNING", "message": "{object} uses uppercase characters.", "advices": "Using uppercase in identifiers requires quoting and can cause case-sensitivity issues.", "infos": ["How to fix: Rename the database object to use only lowercase characters."]}'),
-('B006', '{"severity": "WARNING", "message": "{object} has never been selected.", "advices": "Review the necessity of this table. If it is not needed, consider removing it or archiving its data.", "infos": ["How to fix: DROP TABLE {object}; or investigate application usage."]}'),
-('B007', '{"severity": "WARNING", "message": "{object} has foreign keys outside its schema.", "advices": "Consider restructuring schema design to keep related tables in the same schema.", "infos": ["How to fix: Move related tables into the same schema or review schema design."]}'),
-('B008', '{"severity": "WARNING", "message": "{object} has a foreign key type mismatch.", "advices": "Adjust column types to ensure foreign key matches referenced key type.", "infos": ["How to fix: ALTER TABLE {object} ALTER COLUMN ... TYPE ...;"]}'),
-('B009', '{"severity": "WARNING", "message": "{object} shares a trigger function with other tables.", "advices": "Use one trigger function per table for clarity and maintainability.", "infos": ["How to fix: CREATE a dedicated trigger function for {object} and update the trigger."]}'),
-('B010', '{"severity": "WARNING", "message": "{object} uses a reserved SQL keyword as its name.", "advices": "Rename database objects to avoid using reserved keywords.", "infos": ["How to fix: ALTER TABLE/INDEX/VIEW/FUNCTION/TYPE {object} RENAME TO ...;"]}'),
-('B011', '{"severity": "WARNING", "message": "{object} schema has tables with different owners.", "advices": "Change table owners to the same functional role for easier maintenance.", "infos": ["How to fix: ALTER TABLE {object} OWNER TO ...;"]}'),
-('B012', '{"severity": "WARNING", "message": "{object} has a composite primary key with more than 4 columns.", "advices": "Consider redesigning the table to avoid composite primary keys with more than 4 columns. Use surrogate keys if possible.", "infos": ["How to fix: Redesign {object} to use a surrogate key and unique constraints."]}'),
-('B013', '{"severity": "WARNING", "message": "{object} uses a trigger function, that uses a cursor and a row by row processing, without any WHERE clause. Fired trigger can cause performance issues.", "advices": "If possible avoid row by row processing. Use base processing instead. If not possible, then add a where clause to limit the number of returned rows.", "infos": ["How to fix: remove the cursor or add a where clause to the cursor. {object}."]}');
+(
+    'B001',
+    '{"severity": "WARNING", "message": "{object} does not have a primary key.", "advices": "Add a primary key to this table to ensure data integrity and better performance.", "infos": ["How to fix: ALTER TABLE {object} ADD PRIMARY KEY (...);"]}'
+),
+(
+    'B002',
+    '{"severity": "WARNING", "message": "{object} is a redundant index.", "advices": "Remove redundant or duplicate indexes to optimize performance and storage.", "infos": ["How to fix: DROP INDEX {object}; or review constraints that may create duplicate indexes."]}'
+),
+(
+    'B003',
+    '{"severity": "WARNING", "message": "{object} does not have an index on its foreign key.", "advices": "Create an index on the foreign key column to improve join and lookup performance.", "infos": ["How to fix: CREATE INDEX ON {object} (...);"]}'
+),
+(
+    'B004',
+    '{"severity": "WARNING", "message": "{object} is an unused index.", "advices": "Remove unused indexes to reduce storage and maintenance overhead.", "infos": ["How to fix: DROP INDEX {object}; or review index usage statistics."]}'
+),
+(
+    'B005',
+    '{"severity": "WARNING", "message": "{object} uses uppercase characters.", "advices": "Using uppercase in identifiers requires quoting and can cause case-sensitivity issues.", "infos": ["How to fix: Rename the database object to use only lowercase characters."]}'
+),
+(
+    'B006',
+    '{"severity": "WARNING", "message": "{object} has never been selected.", "advices": "Review the necessity of this table. If it is not needed, consider removing it or archiving its data.", "infos": ["How to fix: DROP TABLE {object}; or investigate application usage."]}'
+),
+(
+    'B007',
+    '{"severity": "WARNING", "message": "{object} has foreign keys outside its schema.", "advices": "Consider restructuring schema design to keep related tables in the same schema.", "infos": ["How to fix: Move related tables into the same schema or review schema design."]}'
+),
+(
+    'B008',
+    '{"severity": "WARNING", "message": "{object} has a foreign key type mismatch.", "advices": "Adjust column types to ensure foreign key matches referenced key type.", "infos": ["How to fix: ALTER TABLE {object} ALTER COLUMN ... TYPE ...;"]}'
+),
+(
+    'B009',
+    '{"severity": "WARNING", "message": "{object} shares a trigger function with other tables.", "advices": "Use one trigger function per table for clarity and maintainability.", "infos": ["How to fix: CREATE a dedicated trigger function for {object} and update the trigger."]}'
+),
+(
+    'B010',
+    '{"severity": "WARNING", "message": "{object} uses a reserved SQL keyword as its name.", "advices": "Rename database objects to avoid using reserved keywords.", "infos": ["How to fix: ALTER TABLE/INDEX/VIEW/FUNCTION/TYPE {object} RENAME TO ...;"]}'
+),
+(
+    'B011',
+    '{"severity": "WARNING", "message": "{object} schema has tables with different owners.", "advices": "Change table owners to the same functional role for easier maintenance.", "infos": ["How to fix: ALTER TABLE {object} OWNER TO ...;"]}'
+),
+(
+    'B012',
+    '{"severity": "WARNING", "message": "{object} has a composite primary key with more than 4 columns.", "advices": "Consider redesigning the table to avoid composite primary keys with more than 4 columns. Use surrogate keys if possible.", "infos": ["How to fix: Redesign {object} to use a surrogate key and unique constraints."]}'
+),
+(
+    'B013',
+    '{"severity": "WARNING", "message": "{object} uses a trigger function, that uses a cursor and a row by row processing, without any WHERE clause. Fired trigger can cause performance issues.", "advices": "If possible avoid row by row processing. Use base processing instead. If not possible, then add a where clause to limit the number of returned rows.", "infos": ["How to fix: remove the cursor or add a where clause to the cursor. {object}."]}'
+);

--- a/sql/rules.sql
+++ b/sql/rules.sql
@@ -143,8 +143,17 @@ INSERT INTO pglinter.rules (
     'Detect tables with composite primary keys involving more than 4 columns',
     '{0} table(s) have composite primary keys with more than 4 columns. Object list:\n{4}',
     ARRAY[
-      'Consider redesigning the table to avoid composite primary keys with more than 4 columns',
-      'Use surrogate keys (e.g., serial, UUID) instead of composite primary keys, and establish unique constraints on necessary column combinations, to enforce uniqueness.'
+        'Consider redesigning the table to avoid composite primary keys with more than 4 columns',
+        'Use surrogate keys (e.g., serial, UUID) instead of composite primary keys, and establish unique constraints on necessary column combinations, to enforce uniqueness.'
+    ]
+),
+(
+    'HowManyTablesWithRowByRowTriggerWithoutWhereClause', 'B013', 20, 80, 'BASE',
+    'Count number of tables using a row by row processing without any where clause vs nb table with their own triggers.',
+    '{0}/{1} table(s) using row by row processing without any where clause exceed the {2} threshold: {3}%. Object list:\n{4}',
+    ARRAY[
+        'Prefer using set-based operations instead of row by row processing for better performance.',
+        'If not possible, consider adding a WHERE clause to limit the rows processed.'
     ]
 ),
 (
@@ -1772,6 +1781,101 @@ JOIN pg_class c
 $$
 WHERE code = 'B012';
 
+
+-- =============================================================================
+-- B013 - Tables With row by row processing without any where clause
+-- =============================================================================
+UPDATE pglinter.rules
+SET q1 = $$
+SELECT
+    COALESCE(COUNT(DISTINCT event_object_table), 0)::BIGINT as table_using_trigger
+FROM
+    information_schema.triggers t
+WHERE
+    t.trigger_schema NOT IN (
+    'pg_toast', 'pg_catalog', 'information_schema', 'pglinter'
+)
+$$,
+  q2 = $$
+SELECT
+    COUNT(DISTINCT c.oid)::BIGINT AS tables_with_unbounded_cursor_trigger
+FROM pg_trigger tg
+JOIN pg_class     c  ON c.oid = tg.tgrelid
+JOIN pg_namespace n  ON n.oid = c.relnamespace
+JOIN pg_proc      p  ON p.oid = tg.tgfoid
+WHERE
+    NOT tg.tgisinternal
+    AND p.prolang = (SELECT oid FROM pg_language WHERE lanname = 'plpgsql')
+    AND n.nspname NOT IN (
+        'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
+    )
+    -- function body has a cursor/FOR-loop SELECT ...
+    AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
+    -- but none of those SELECT blocks contain a WHERE keyword
+    AND NOT (
+        (regexp_matches(
+            p.prosrc,
+            '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
+            'gix'
+        ))[1] ~* '\mWHERE\M'
+    )
+$$,
+  q3 = $$
+SELECT
+    n.nspname::TEXT                          AS schema_name,
+    c.relname::TEXT                          AS table_name,
+    tg.tgname::TEXT || ' -> ' ||
+    pn.nspname::TEXT || '.' ||
+    p.proname::TEXT                          AS trigger_and_function
+FROM pg_trigger    tg
+JOIN pg_class      c   ON c.oid  = tg.tgrelid
+JOIN pg_namespace  n   ON n.oid  = c.relnamespace
+JOIN pg_proc       p   ON p.oid  = tg.tgfoid
+JOIN pg_namespace  pn  ON pn.oid = p.pronamespace
+WHERE
+    NOT tg.tgisinternal
+    AND p.prolang = (SELECT oid FROM pg_language WHERE lanname = 'plpgsql')
+    AND n.nspname NOT IN (
+        'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
+    )
+    AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
+    AND NOT (
+        (regexp_matches(
+            p.prosrc,
+            '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
+            'gix'
+        ))[1] ~* '\mWHERE\M'
+    )
+ORDER BY n.nspname, c.relname, tg.tgname
+$$,
+  q4 = $$
+SELECT
+    'pg_trigger'::regclass::oid AS classid,
+    tg.oid                      AS objid,
+    0                           AS objsubid
+FROM pg_trigger    tg
+JOIN pg_class      c  ON c.oid = tg.tgrelid
+JOIN pg_namespace  n  ON n.oid = c.relnamespace
+JOIN pg_proc       p  ON p.oid = tg.tgfoid
+WHERE
+    NOT tg.tgisinternal
+    AND p.prolang = (SELECT oid FROM pg_language WHERE lanname = 'plpgsql')
+    AND n.nspname NOT IN (
+        'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
+    )
+    AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
+    AND NOT (
+        (regexp_matches(
+            p.prosrc,
+            '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
+            'gix'
+        ))[1] ~* '\mWHERE\M'
+    )
+$$
+WHERE code = 'B013';
+
+
+
 -- =============================================================================
 -- S001 - Schema Permission Analysis
 -- =============================================================================
@@ -2148,4 +2252,5 @@ INSERT INTO pglinter.rule_messages (code, rule_msg) VALUES
 ('B009', '{"severity": "WARNING", "message": "{object} shares a trigger function with other tables.", "advices": "Use one trigger function per table for clarity and maintainability.", "infos": ["How to fix: CREATE a dedicated trigger function for {object} and update the trigger."]}'),
 ('B010', '{"severity": "WARNING", "message": "{object} uses a reserved SQL keyword as its name.", "advices": "Rename database objects to avoid using reserved keywords.", "infos": ["How to fix: ALTER TABLE/INDEX/VIEW/FUNCTION/TYPE {object} RENAME TO ...;"]}'),
 ('B011', '{"severity": "WARNING", "message": "{object} schema has tables with different owners.", "advices": "Change table owners to the same functional role for easier maintenance.", "infos": ["How to fix: ALTER TABLE {object} OWNER TO ...;"]}'),
-('B012', '{"severity": "WARNING", "message": "{object} has a composite primary key with more than 4 columns.", "advices": "Consider redesigning the table to avoid composite primary keys with more than 4 columns. Use surrogate keys if possible.", "infos": ["How to fix: Redesign {object} to use a surrogate key and unique constraints."]}');
+('B012', '{"severity": "WARNING", "message": "{object} has a composite primary key with more than 4 columns.", "advices": "Consider redesigning the table to avoid composite primary keys with more than 4 columns. Use surrogate keys if possible.", "infos": ["How to fix: Redesign {object} to use a surrogate key and unique constraints."]}'),
+('B013', '{"severity": "WARNING", "message": "{object} uses a trigger function, that uses a cursor and a row by row processing, without any WHERE clause. Fired trigger can cause performance issues.", "advices": "If possible avoid row by row processing. Use base processing instead. If not possible, then add a where clause to limit the number of returned rows.", "infos": ["How to fix: remove the cursor or add a where clause to the cursor. {object}."]}');

--- a/tests/expected/b001.out
+++ b/tests/expected/b001.out
@@ -12,10 +12,10 @@ CREATE TABLE my_table_without_pk (
 );
 -- Disable all rules first
 SELECT pglinter.disable_all_rules() AS all_rules_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_rules_disabled 
 --------------------
-                 20
+                 21
 (1 row)
 
 -- Run table check to detect tables without PK

--- a/tests/expected/b001_configurable.out
+++ b/tests/expected/b001_configurable.out
@@ -15,10 +15,10 @@ CREATE TABLE test_with_pk (
 );
 -- First, disable all rules to isolate B001 testing
 SELECT pglinter.disable_all_rules() AS all_rules_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_rules_disabled 
 --------------------
-                 20
+                 21
 (1 row)
 
 -- Enable only B001 for focused testing

--- a/tests/expected/b001_primary_keys.out
+++ b/tests/expected/b001_primary_keys.out
@@ -132,10 +132,10 @@ SELECT 'Testing B001 rule - Database-wide primary key percentage analysis...' AS
 
 -- First, disable all rules to isolate B001 testing
 SELECT pglinter.disable_all_rules() AS all_rules_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_rules_disabled 
 --------------------
-                 20
+                 21
 (1 row)
 
 -- Enable only B001 for focused testing

--- a/tests/expected/b002_non_redundant_idx.out
+++ b/tests/expected/b002_non_redundant_idx.out
@@ -26,10 +26,10 @@ CREATE TABLE orders_table (
 );
 -- First, disable all rules to isolate B001 testing
 SELECT pglinter.disable_all_rules() AS all_rules_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_rules_disabled 
 --------------------
-                 20
+                 21
 (1 row)
 
 -- Enable only B002 for focused testing

--- a/tests/expected/b002_redundant_idx.out
+++ b/tests/expected/b002_redundant_idx.out
@@ -49,10 +49,10 @@ CREATE INDEX idx_customer_date_1 ON orders_table (product_name, order_date);
 CREATE INDEX idx_customer_date_2 ON orders_table (product_name, order_date);
 -- First, disable all rules to isolate B001 testing
 SELECT pglinter.disable_all_rules() AS all_rules_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_rules_disabled 
 --------------------
-                 20
+                 21
 (1 row)
 
 -- Enable only B002 for focused testing

--- a/tests/expected/b003_fk_not_indexed.out
+++ b/tests/expected/b003_fk_not_indexed.out
@@ -109,10 +109,10 @@ SELECT 'Testing B003 rule - Foreign keys without indexes detection...' AS test_i
 
 -- First, disable all rules to isolate B003 testing
 SELECT pglinter.disable_all_rules() AS all_rules_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_rules_disabled 
 --------------------
-                 20
+                 21
 (1 row)
 
 -- Enable only B003 for focused testing

--- a/tests/expected/b005_uppercase_test.out
+++ b/tests/expected/b005_uppercase_test.out
@@ -78,10 +78,10 @@ SELECT 'Testing B005 rule - Comprehensive uppercase object detection...' AS test
 
 -- First, disable all rules to isolate B005 testing
 SELECT pglinter.disable_all_rules() AS all_rules_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_rules_disabled 
 --------------------
-                 20
+                 21
 (1 row)
 
 -- Enable only B005 for focused testing

--- a/tests/expected/b007_fk_outside_schema.out
+++ b/tests/expected/b007_fk_outside_schema.out
@@ -157,60 +157,51 @@ SELECT 'Running base check to test B007 rule:' AS test_step;
 (1 row)
 
 SELECT pglinter.check();
-ERROR:  set-returning functions are not allowed in WHERE
-LINE 18:         (regexp_matches(
-                  ^
-QUERY:  
-SELECT
-    COUNT(DISTINCT c.oid)::BIGINT AS tables_with_unbounded_cursor_trigger
-FROM pg_trigger tg
-JOIN pg_class     c  ON c.oid = tg.tgrelid
-JOIN pg_namespace n  ON n.oid = c.relnamespace
-JOIN pg_proc      p  ON p.oid = tg.tgfoid
-WHERE
-    NOT tg.tgisinternal
-    AND p.prolang = (SELECT oid FROM pg_language WHERE lanname = 'plpgsql')
-    AND n.nspname NOT IN (
-        'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
-    )
-    -- function body has a cursor/FOR-loop SELECT ...
-    AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
-    -- but none of those SELECT blocks contain a WHERE keyword
-    AND NOT (
-        (regexp_matches(
-            p.prosrc,
-            '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
-            'gix'
-        ))[1] ~* '\mWHERE\M'
-    )
+NOTICE:  🔍 pglinter found 6 issue(s):
+NOTICE:  ==================================================
+NOTICE:  ❌ [B003] ERROR: 6/6 table(s) without index on foreign key exceed the error threshold: 100%. Object list:
+audit_schema.user_actions.user_actions_user_id_fkey
+clean_schema.employees.employees_department_id_fkey
+inventory_schema.stock_movements.stock_movements_product_id_fkey
+public_schema.customer_addresses.customer_addresses_customer_id_fkey
+sales_schema.order_items.order_items_order_id_fkey
+sales_schema.order_items.order_items_product_id_fkey
+sales_schema.orders.orders_customer_id_fkey
+
+NOTICE:  ⚠️  [B007] WARNING: 4/6 table(s) with foreign keys outside schema exceed the warning threshold: 66%. Object list:
+sales_schema.orders.has foreign key orders_customer_id_fkey referencing public_schema.customers
+sales_schema.order_items.has foreign key order_items_product_id_fkey referencing public_schema.products
+inventory_schema.stock_movements.has foreign key stock_movements_product_id_fkey referencing public_schema.products
+audit_schema.user_actions.has foreign key user_actions_user_id_fkey referencing public_schema.users
+
+NOTICE:  ⚠️  [C001] WARNING: CLUSTER {0} entries in pg_hba.conf with trust authentication method exceed the warning threshold: {1}. 1 : 
+Row 1 
+
+NOTICE:  ❌ [C002] ERROR: 6 entries in pg_hba.conf with trust or password authentication method exceed the warning threshold: 6.
+NOTICE:  ❌ [S001] ERROR: No default role grantee on schema 6.6. It means that each time a table is created, you must grant it to roles. Object list:
+audit_schema
+clean_schema
+inventory_schema
+public
+public_schema
+sales_schema
+
+NOTICE:  ⚠️  [S003] WARNING: 1/6 schemas are unsecured, schemas where all users can create objects in, exceed the warning threshold: 16%. Object list:
+public
+
+NOTICE:  ==================================================
+NOTICE:  📊 Summary: 3 error(s), 3 warning(s), 0 info
+NOTICE:  🔴 Critical issues found - please review and fix errors
+ check 
+-------
+ t
+(1 row)
 
 SELECT count(*) AS violation_count from pglinter.get_violations() WHERE rule_code = 'B007';
-ERROR:  set-returning functions are not allowed in WHERE
-LINE 18:         (regexp_matches(
-                  ^
-QUERY:  
-SELECT
-    'pg_trigger'::regclass::oid AS classid,
-    tg.oid                      AS objid,
-    0                           AS objsubid
-FROM pg_trigger    tg
-JOIN pg_class      c  ON c.oid = tg.tgrelid
-JOIN pg_namespace  n  ON n.oid = c.relnamespace
-JOIN pg_proc       p  ON p.oid = tg.tgfoid
-WHERE
-    NOT tg.tgisinternal
-    AND p.prolang = (SELECT oid FROM pg_language WHERE lanname = 'plpgsql')
-    AND n.nspname NOT IN (
-        'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
-    )
-    AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
-    AND NOT (
-        (regexp_matches(
-            p.prosrc,
-            '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
-            'gix'
-        ))[1] ~* '\mWHERE\M'
-    )
+ violation_count 
+-----------------
+               4
+(1 row)
 
 -- Test rule management for B007
 SELECT 'Testing B007 rule management...' AS test_step;
@@ -262,60 +253,45 @@ NOTICE:  🔴 Rule B007 has been disabled
 (1 row)
 
 SELECT pglinter.check(); -- Should skip B007
-ERROR:  set-returning functions are not allowed in WHERE
-LINE 18:         (regexp_matches(
-                  ^
-QUERY:  
-SELECT
-    COUNT(DISTINCT c.oid)::BIGINT AS tables_with_unbounded_cursor_trigger
-FROM pg_trigger tg
-JOIN pg_class     c  ON c.oid = tg.tgrelid
-JOIN pg_namespace n  ON n.oid = c.relnamespace
-JOIN pg_proc      p  ON p.oid = tg.tgfoid
-WHERE
-    NOT tg.tgisinternal
-    AND p.prolang = (SELECT oid FROM pg_language WHERE lanname = 'plpgsql')
-    AND n.nspname NOT IN (
-        'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
-    )
-    -- function body has a cursor/FOR-loop SELECT ...
-    AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
-    -- but none of those SELECT blocks contain a WHERE keyword
-    AND NOT (
-        (regexp_matches(
-            p.prosrc,
-            '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
-            'gix'
-        ))[1] ~* '\mWHERE\M'
-    )
+NOTICE:  🔍 pglinter found 5 issue(s):
+NOTICE:  ==================================================
+NOTICE:  ❌ [B003] ERROR: 6/6 table(s) without index on foreign key exceed the error threshold: 100%. Object list:
+audit_schema.user_actions.user_actions_user_id_fkey
+clean_schema.employees.employees_department_id_fkey
+inventory_schema.stock_movements.stock_movements_product_id_fkey
+public_schema.customer_addresses.customer_addresses_customer_id_fkey
+sales_schema.order_items.order_items_order_id_fkey
+sales_schema.order_items.order_items_product_id_fkey
+sales_schema.orders.orders_customer_id_fkey
+
+NOTICE:  ⚠️  [C001] WARNING: CLUSTER {0} entries in pg_hba.conf with trust authentication method exceed the warning threshold: {1}. 1 : 
+Row 1 
+
+NOTICE:  ❌ [C002] ERROR: 6 entries in pg_hba.conf with trust or password authentication method exceed the warning threshold: 6.
+NOTICE:  ❌ [S001] ERROR: No default role grantee on schema 6.6. It means that each time a table is created, you must grant it to roles. Object list:
+audit_schema
+clean_schema
+inventory_schema
+public
+public_schema
+sales_schema
+
+NOTICE:  ⚠️  [S003] WARNING: 1/6 schemas are unsecured, schemas where all users can create objects in, exceed the warning threshold: 16%. Object list:
+public
+
+NOTICE:  ==================================================
+NOTICE:  📊 Summary: 3 error(s), 2 warning(s), 0 info
+NOTICE:  🔴 Critical issues found - please review and fix errors
+ check 
+-------
+ t
+(1 row)
 
 SELECT count(*) AS violation_count from pglinter.get_violations() WHERE rule_code = 'B007';
-ERROR:  set-returning functions are not allowed in WHERE
-LINE 18:         (regexp_matches(
-                  ^
-QUERY:  
-SELECT
-    'pg_trigger'::regclass::oid AS classid,
-    tg.oid                      AS objid,
-    0                           AS objsubid
-FROM pg_trigger    tg
-JOIN pg_class      c  ON c.oid = tg.tgrelid
-JOIN pg_namespace  n  ON n.oid = c.relnamespace
-JOIN pg_proc       p  ON p.oid = tg.tgfoid
-WHERE
-    NOT tg.tgisinternal
-    AND p.prolang = (SELECT oid FROM pg_language WHERE lanname = 'plpgsql')
-    AND n.nspname NOT IN (
-        'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
-    )
-    AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
-    AND NOT (
-        (regexp_matches(
-            p.prosrc,
-            '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
-            'gix'
-        ))[1] ~* '\mWHERE\M'
-    )
+ violation_count 
+-----------------
+               0
+(1 row)
 
 -- Re-enable B007
 SELECT 'Testing B007 re-enable...' AS test_step;
@@ -332,60 +308,51 @@ NOTICE:  ✅ Rule B007 has been enabled
 (1 row)
 
 SELECT pglinter.check(); -- Should include B007 again
-ERROR:  set-returning functions are not allowed in WHERE
-LINE 18:         (regexp_matches(
-                  ^
-QUERY:  
-SELECT
-    COUNT(DISTINCT c.oid)::BIGINT AS tables_with_unbounded_cursor_trigger
-FROM pg_trigger tg
-JOIN pg_class     c  ON c.oid = tg.tgrelid
-JOIN pg_namespace n  ON n.oid = c.relnamespace
-JOIN pg_proc      p  ON p.oid = tg.tgfoid
-WHERE
-    NOT tg.tgisinternal
-    AND p.prolang = (SELECT oid FROM pg_language WHERE lanname = 'plpgsql')
-    AND n.nspname NOT IN (
-        'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
-    )
-    -- function body has a cursor/FOR-loop SELECT ...
-    AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
-    -- but none of those SELECT blocks contain a WHERE keyword
-    AND NOT (
-        (regexp_matches(
-            p.prosrc,
-            '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
-            'gix'
-        ))[1] ~* '\mWHERE\M'
-    )
+NOTICE:  🔍 pglinter found 6 issue(s):
+NOTICE:  ==================================================
+NOTICE:  ❌ [B003] ERROR: 6/6 table(s) without index on foreign key exceed the error threshold: 100%. Object list:
+audit_schema.user_actions.user_actions_user_id_fkey
+clean_schema.employees.employees_department_id_fkey
+inventory_schema.stock_movements.stock_movements_product_id_fkey
+public_schema.customer_addresses.customer_addresses_customer_id_fkey
+sales_schema.order_items.order_items_order_id_fkey
+sales_schema.order_items.order_items_product_id_fkey
+sales_schema.orders.orders_customer_id_fkey
+
+NOTICE:  ⚠️  [B007] WARNING: 4/6 table(s) with foreign keys outside schema exceed the warning threshold: 66%. Object list:
+sales_schema.orders.has foreign key orders_customer_id_fkey referencing public_schema.customers
+sales_schema.order_items.has foreign key order_items_product_id_fkey referencing public_schema.products
+inventory_schema.stock_movements.has foreign key stock_movements_product_id_fkey referencing public_schema.products
+audit_schema.user_actions.has foreign key user_actions_user_id_fkey referencing public_schema.users
+
+NOTICE:  ⚠️  [C001] WARNING: CLUSTER {0} entries in pg_hba.conf with trust authentication method exceed the warning threshold: {1}. 1 : 
+Row 1 
+
+NOTICE:  ❌ [C002] ERROR: 6 entries in pg_hba.conf with trust or password authentication method exceed the warning threshold: 6.
+NOTICE:  ❌ [S001] ERROR: No default role grantee on schema 6.6. It means that each time a table is created, you must grant it to roles. Object list:
+audit_schema
+clean_schema
+inventory_schema
+public
+public_schema
+sales_schema
+
+NOTICE:  ⚠️  [S003] WARNING: 1/6 schemas are unsecured, schemas where all users can create objects in, exceed the warning threshold: 16%. Object list:
+public
+
+NOTICE:  ==================================================
+NOTICE:  📊 Summary: 3 error(s), 3 warning(s), 0 info
+NOTICE:  🔴 Critical issues found - please review and fix errors
+ check 
+-------
+ t
+(1 row)
 
 SELECT count(*) AS violation_count from pglinter.get_violations() WHERE rule_code = 'B007';
-ERROR:  set-returning functions are not allowed in WHERE
-LINE 18:         (regexp_matches(
-                  ^
-QUERY:  
-SELECT
-    'pg_trigger'::regclass::oid AS classid,
-    tg.oid                      AS objid,
-    0                           AS objsubid
-FROM pg_trigger    tg
-JOIN pg_class      c  ON c.oid = tg.tgrelid
-JOIN pg_namespace  n  ON n.oid = c.relnamespace
-JOIN pg_proc       p  ON p.oid = tg.tgfoid
-WHERE
-    NOT tg.tgisinternal
-    AND p.prolang = (SELECT oid FROM pg_language WHERE lanname = 'plpgsql')
-    AND n.nspname NOT IN (
-        'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
-    )
-    AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
-    AND NOT (
-        (regexp_matches(
-            p.prosrc,
-            '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
-            'gix'
-        ))[1] ~* '\mWHERE\M'
-    )
+ violation_count 
+-----------------
+               4
+(1 row)
 
 -- Test with only B007 enabled
 SELECT 'Testing B007 in isolation...' AS test_step;

--- a/tests/expected/b007_fk_outside_schema.out
+++ b/tests/expected/b007_fk_outside_schema.out
@@ -157,51 +157,60 @@ SELECT 'Running base check to test B007 rule:' AS test_step;
 (1 row)
 
 SELECT pglinter.check();
-NOTICE:  🔍 pglinter found 6 issue(s):
-NOTICE:  ==================================================
-NOTICE:  ❌ [B003] ERROR: 6/6 table(s) without index on foreign key exceed the error threshold: 100%. Object list:
-audit_schema.user_actions.user_actions_user_id_fkey
-clean_schema.employees.employees_department_id_fkey
-inventory_schema.stock_movements.stock_movements_product_id_fkey
-public_schema.customer_addresses.customer_addresses_customer_id_fkey
-sales_schema.order_items.order_items_order_id_fkey
-sales_schema.order_items.order_items_product_id_fkey
-sales_schema.orders.orders_customer_id_fkey
-
-NOTICE:  ⚠️  [B007] WARNING: 4/6 table(s) with foreign keys outside schema exceed the warning threshold: 66%. Object list:
-sales_schema.orders.has foreign key orders_customer_id_fkey referencing public_schema.customers
-sales_schema.order_items.has foreign key order_items_product_id_fkey referencing public_schema.products
-inventory_schema.stock_movements.has foreign key stock_movements_product_id_fkey referencing public_schema.products
-audit_schema.user_actions.has foreign key user_actions_user_id_fkey referencing public_schema.users
-
-NOTICE:  ⚠️  [C001] WARNING: CLUSTER {0} entries in pg_hba.conf with trust authentication method exceed the warning threshold: {1}. 1 : 
-Row 1 
-
-NOTICE:  ❌ [C002] ERROR: 6 entries in pg_hba.conf with trust or password authentication method exceed the warning threshold: 6.
-NOTICE:  ❌ [S001] ERROR: No default role grantee on schema 6.6. It means that each time a table is created, you must grant it to roles. Object list:
-audit_schema
-clean_schema
-inventory_schema
-public
-public_schema
-sales_schema
-
-NOTICE:  ⚠️  [S003] WARNING: 1/6 schemas are unsecured, schemas where all users can create objects in, exceed the warning threshold: 16%. Object list:
-public
-
-NOTICE:  ==================================================
-NOTICE:  📊 Summary: 3 error(s), 3 warning(s), 0 info
-NOTICE:  🔴 Critical issues found - please review and fix errors
- check 
--------
- t
-(1 row)
+ERROR:  set-returning functions are not allowed in WHERE
+LINE 18:         (regexp_matches(
+                  ^
+QUERY:  
+SELECT
+    COUNT(DISTINCT c.oid)::BIGINT AS tables_with_unbounded_cursor_trigger
+FROM pg_trigger tg
+JOIN pg_class     c  ON c.oid = tg.tgrelid
+JOIN pg_namespace n  ON n.oid = c.relnamespace
+JOIN pg_proc      p  ON p.oid = tg.tgfoid
+WHERE
+    NOT tg.tgisinternal
+    AND p.prolang = (SELECT oid FROM pg_language WHERE lanname = 'plpgsql')
+    AND n.nspname NOT IN (
+        'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
+    )
+    -- function body has a cursor/FOR-loop SELECT ...
+    AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
+    -- but none of those SELECT blocks contain a WHERE keyword
+    AND NOT (
+        (regexp_matches(
+            p.prosrc,
+            '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
+            'gix'
+        ))[1] ~* '\mWHERE\M'
+    )
 
 SELECT count(*) AS violation_count from pglinter.get_violations() WHERE rule_code = 'B007';
- violation_count 
------------------
-               4
-(1 row)
+ERROR:  set-returning functions are not allowed in WHERE
+LINE 18:         (regexp_matches(
+                  ^
+QUERY:  
+SELECT
+    'pg_trigger'::regclass::oid AS classid,
+    tg.oid                      AS objid,
+    0                           AS objsubid
+FROM pg_trigger    tg
+JOIN pg_class      c  ON c.oid = tg.tgrelid
+JOIN pg_namespace  n  ON n.oid = c.relnamespace
+JOIN pg_proc       p  ON p.oid = tg.tgfoid
+WHERE
+    NOT tg.tgisinternal
+    AND p.prolang = (SELECT oid FROM pg_language WHERE lanname = 'plpgsql')
+    AND n.nspname NOT IN (
+        'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
+    )
+    AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
+    AND NOT (
+        (regexp_matches(
+            p.prosrc,
+            '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
+            'gix'
+        ))[1] ~* '\mWHERE\M'
+    )
 
 -- Test rule management for B007
 SELECT 'Testing B007 rule management...' AS test_step;
@@ -253,45 +262,60 @@ NOTICE:  🔴 Rule B007 has been disabled
 (1 row)
 
 SELECT pglinter.check(); -- Should skip B007
-NOTICE:  🔍 pglinter found 5 issue(s):
-NOTICE:  ==================================================
-NOTICE:  ❌ [B003] ERROR: 6/6 table(s) without index on foreign key exceed the error threshold: 100%. Object list:
-audit_schema.user_actions.user_actions_user_id_fkey
-clean_schema.employees.employees_department_id_fkey
-inventory_schema.stock_movements.stock_movements_product_id_fkey
-public_schema.customer_addresses.customer_addresses_customer_id_fkey
-sales_schema.order_items.order_items_order_id_fkey
-sales_schema.order_items.order_items_product_id_fkey
-sales_schema.orders.orders_customer_id_fkey
-
-NOTICE:  ⚠️  [C001] WARNING: CLUSTER {0} entries in pg_hba.conf with trust authentication method exceed the warning threshold: {1}. 1 : 
-Row 1 
-
-NOTICE:  ❌ [C002] ERROR: 6 entries in pg_hba.conf with trust or password authentication method exceed the warning threshold: 6.
-NOTICE:  ❌ [S001] ERROR: No default role grantee on schema 6.6. It means that each time a table is created, you must grant it to roles. Object list:
-audit_schema
-clean_schema
-inventory_schema
-public
-public_schema
-sales_schema
-
-NOTICE:  ⚠️  [S003] WARNING: 1/6 schemas are unsecured, schemas where all users can create objects in, exceed the warning threshold: 16%. Object list:
-public
-
-NOTICE:  ==================================================
-NOTICE:  📊 Summary: 3 error(s), 2 warning(s), 0 info
-NOTICE:  🔴 Critical issues found - please review and fix errors
- check 
--------
- t
-(1 row)
+ERROR:  set-returning functions are not allowed in WHERE
+LINE 18:         (regexp_matches(
+                  ^
+QUERY:  
+SELECT
+    COUNT(DISTINCT c.oid)::BIGINT AS tables_with_unbounded_cursor_trigger
+FROM pg_trigger tg
+JOIN pg_class     c  ON c.oid = tg.tgrelid
+JOIN pg_namespace n  ON n.oid = c.relnamespace
+JOIN pg_proc      p  ON p.oid = tg.tgfoid
+WHERE
+    NOT tg.tgisinternal
+    AND p.prolang = (SELECT oid FROM pg_language WHERE lanname = 'plpgsql')
+    AND n.nspname NOT IN (
+        'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
+    )
+    -- function body has a cursor/FOR-loop SELECT ...
+    AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
+    -- but none of those SELECT blocks contain a WHERE keyword
+    AND NOT (
+        (regexp_matches(
+            p.prosrc,
+            '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
+            'gix'
+        ))[1] ~* '\mWHERE\M'
+    )
 
 SELECT count(*) AS violation_count from pglinter.get_violations() WHERE rule_code = 'B007';
- violation_count 
------------------
-               0
-(1 row)
+ERROR:  set-returning functions are not allowed in WHERE
+LINE 18:         (regexp_matches(
+                  ^
+QUERY:  
+SELECT
+    'pg_trigger'::regclass::oid AS classid,
+    tg.oid                      AS objid,
+    0                           AS objsubid
+FROM pg_trigger    tg
+JOIN pg_class      c  ON c.oid = tg.tgrelid
+JOIN pg_namespace  n  ON n.oid = c.relnamespace
+JOIN pg_proc       p  ON p.oid = tg.tgfoid
+WHERE
+    NOT tg.tgisinternal
+    AND p.prolang = (SELECT oid FROM pg_language WHERE lanname = 'plpgsql')
+    AND n.nspname NOT IN (
+        'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
+    )
+    AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
+    AND NOT (
+        (regexp_matches(
+            p.prosrc,
+            '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
+            'gix'
+        ))[1] ~* '\mWHERE\M'
+    )
 
 -- Re-enable B007
 SELECT 'Testing B007 re-enable...' AS test_step;
@@ -308,51 +332,60 @@ NOTICE:  ✅ Rule B007 has been enabled
 (1 row)
 
 SELECT pglinter.check(); -- Should include B007 again
-NOTICE:  🔍 pglinter found 6 issue(s):
-NOTICE:  ==================================================
-NOTICE:  ❌ [B003] ERROR: 6/6 table(s) without index on foreign key exceed the error threshold: 100%. Object list:
-audit_schema.user_actions.user_actions_user_id_fkey
-clean_schema.employees.employees_department_id_fkey
-inventory_schema.stock_movements.stock_movements_product_id_fkey
-public_schema.customer_addresses.customer_addresses_customer_id_fkey
-sales_schema.order_items.order_items_order_id_fkey
-sales_schema.order_items.order_items_product_id_fkey
-sales_schema.orders.orders_customer_id_fkey
-
-NOTICE:  ⚠️  [B007] WARNING: 4/6 table(s) with foreign keys outside schema exceed the warning threshold: 66%. Object list:
-sales_schema.orders.has foreign key orders_customer_id_fkey referencing public_schema.customers
-sales_schema.order_items.has foreign key order_items_product_id_fkey referencing public_schema.products
-inventory_schema.stock_movements.has foreign key stock_movements_product_id_fkey referencing public_schema.products
-audit_schema.user_actions.has foreign key user_actions_user_id_fkey referencing public_schema.users
-
-NOTICE:  ⚠️  [C001] WARNING: CLUSTER {0} entries in pg_hba.conf with trust authentication method exceed the warning threshold: {1}. 1 : 
-Row 1 
-
-NOTICE:  ❌ [C002] ERROR: 6 entries in pg_hba.conf with trust or password authentication method exceed the warning threshold: 6.
-NOTICE:  ❌ [S001] ERROR: No default role grantee on schema 6.6. It means that each time a table is created, you must grant it to roles. Object list:
-audit_schema
-clean_schema
-inventory_schema
-public
-public_schema
-sales_schema
-
-NOTICE:  ⚠️  [S003] WARNING: 1/6 schemas are unsecured, schemas where all users can create objects in, exceed the warning threshold: 16%. Object list:
-public
-
-NOTICE:  ==================================================
-NOTICE:  📊 Summary: 3 error(s), 3 warning(s), 0 info
-NOTICE:  🔴 Critical issues found - please review and fix errors
- check 
--------
- t
-(1 row)
+ERROR:  set-returning functions are not allowed in WHERE
+LINE 18:         (regexp_matches(
+                  ^
+QUERY:  
+SELECT
+    COUNT(DISTINCT c.oid)::BIGINT AS tables_with_unbounded_cursor_trigger
+FROM pg_trigger tg
+JOIN pg_class     c  ON c.oid = tg.tgrelid
+JOIN pg_namespace n  ON n.oid = c.relnamespace
+JOIN pg_proc      p  ON p.oid = tg.tgfoid
+WHERE
+    NOT tg.tgisinternal
+    AND p.prolang = (SELECT oid FROM pg_language WHERE lanname = 'plpgsql')
+    AND n.nspname NOT IN (
+        'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
+    )
+    -- function body has a cursor/FOR-loop SELECT ...
+    AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
+    -- but none of those SELECT blocks contain a WHERE keyword
+    AND NOT (
+        (regexp_matches(
+            p.prosrc,
+            '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
+            'gix'
+        ))[1] ~* '\mWHERE\M'
+    )
 
 SELECT count(*) AS violation_count from pglinter.get_violations() WHERE rule_code = 'B007';
- violation_count 
------------------
-               4
-(1 row)
+ERROR:  set-returning functions are not allowed in WHERE
+LINE 18:         (regexp_matches(
+                  ^
+QUERY:  
+SELECT
+    'pg_trigger'::regclass::oid AS classid,
+    tg.oid                      AS objid,
+    0                           AS objsubid
+FROM pg_trigger    tg
+JOIN pg_class      c  ON c.oid = tg.tgrelid
+JOIN pg_namespace  n  ON n.oid = c.relnamespace
+JOIN pg_proc       p  ON p.oid = tg.tgfoid
+WHERE
+    NOT tg.tgisinternal
+    AND p.prolang = (SELECT oid FROM pg_language WHERE lanname = 'plpgsql')
+    AND n.nspname NOT IN (
+        'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
+    )
+    AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
+    AND NOT (
+        (regexp_matches(
+            p.prosrc,
+            '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
+            'gix'
+        ))[1] ~* '\mWHERE\M'
+    )
 
 -- Test with only B007 enabled
 SELECT 'Testing B007 in isolation...' AS test_step;
@@ -362,10 +395,10 @@ SELECT 'Testing B007 in isolation...' AS test_step;
 (1 row)
 
 SELECT pglinter.disable_all_rules() AS all_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_disabled 
 --------------
-           20
+           21
 (1 row)
 
 SELECT pglinter.enable_rule('B007') AS B007_only_enabled;

--- a/tests/expected/b008_fk_type_mismatch.out
+++ b/tests/expected/b008_fk_type_mismatch.out
@@ -185,10 +185,10 @@ SELECT 'Disabling all rules to test B008 specifically...' AS status;
 (1 row)
 
 SELECT pglinter.disable_all_rules() AS all_rules_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_rules_disabled 
 --------------------
-                 20
+                 21
 (1 row)
 
 SELECT pglinter.enable_rule('B008') AS B008_enabled;

--- a/tests/expected/b009_trigger_sharing.out
+++ b/tests/expected/b009_trigger_sharing.out
@@ -196,10 +196,10 @@ SELECT 'Testing B009 in isolation...' AS test_step;
 (1 row)
 
 SELECT pglinter.disable_all_rules() AS all_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_disabled 
 --------------
-           20
+           21
 (1 row)
 
 SELECT pglinter.enable_rule('B009') AS B009_only_enabled;

--- a/tests/expected/b010_reserved_keywords.out
+++ b/tests/expected/b010_reserved_keywords.out
@@ -183,10 +183,10 @@ SELECT 'Disabling all rules to test B010 specifically...' AS status;
 (1 row)
 
 SELECT pglinter.disable_all_rules() AS all_rules_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_rules_disabled 
 --------------------
-                 20
+                 21
 (1 row)
 
 SELECT pglinter.enable_rule('B010') AS B010_enabled;

--- a/tests/expected/b011_several_table_owner_in_schema.out
+++ b/tests/expected/b011_several_table_owner_in_schema.out
@@ -19,10 +19,10 @@ SELECT 'Testing B011 in isolation...' AS test_step;
 (1 row)
 
 SELECT pglinter.disable_all_rules() AS all_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_disabled 
 --------------
-           20
+           21
 (1 row)
 
 SELECT pglinter.enable_rule('B011') AS B011_only_enabled;

--- a/tests/expected/b012_composite_pk.out
+++ b/tests/expected/b012_composite_pk.out
@@ -2,10 +2,10 @@
 CREATE EXTENSION IF NOT EXISTS pglinter;
 -- First, disable all rules to isolate B001 testing
 SELECT pglinter.disable_all_rules() AS all_rules_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_rules_disabled 
 --------------------
-                 20
+                 21
 (1 row)
 
 -- Enable only B012 for focused testing

--- a/tests/expected/b013_trigger_row_by_row.out
+++ b/tests/expected/b013_trigger_row_by_row.out
@@ -1,0 +1,166 @@
+CREATE EXTENSION IF NOT EXISTS pglinter;
+\pset pager off
+CREATE SCHEMA trigger_test;
+-- =============================================================================
+-- Create test tables
+-- =============================================================================
+-- Tables 1-5: Each will have its own unique trigger function
+CREATE TABLE pos_tnd_ssn_hst
+(
+    id_tnd_ssn_hst integer NOT NULL,
+    id_ssn varchar(32) NOT NULL,
+    id_bsn_un varchar(32) NOT NULL,
+    id_ws varchar(32),
+    id_opr varchar(64),
+    id_safe integer,
+    id_till integer,
+    ts_ssn timestamp,
+    ssn_status varchar(32) NOT NULL,
+    ty_ssn varchar(32),
+    tnd_ssn_data text,
+    ssn_performed_by varchar(64) NOT NULL,
+    tnd_ssn_data_byte bytea,
+    PRIMARY KEY (id_tnd_ssn_hst, id_ssn, id_bsn_un)
+);
+-- =============================================================================
+-- Create unique trigger functions for tables 1-5
+-- =============================================================================
+CREATE FUNCTION f_pos_tnd_ssn_hst() RETURNS trigger
+LANGUAGE plpgsql
+AS
+$$
+DECLARE pos_tnd_ssn_hst_rec RECORD;
+curr CURSOR  FOR SELECT id_tnd_ssn_hst, id_ssn, ssn_status FROM pos_tnd_ssn_hst;
+BEGIN
+	OPEN curr;
+	LOOP
+		FETCH curr INTO pos_tnd_ssn_hst_rec;
+			IF NEW.id_ssn = pos_tnd_ssn_hst_rec.id_ssn AND NEW.ssn_status = pos_tnd_ssn_hst_rec.ssn_status AND NEW.ssn_status <> 'Redeclared' THEN
+			RAISE EXCEPTION 'Invalid Status';
+		END IF;
+    EXIT WHEN NOT FOUND;
+	END LOOP;
+  RETURN NEW;
+END;
+$$;
+CREATE TRIGGER t_pos_tnd_ssn_hst
+BEFORE INSERT OR UPDATE
+ON pos_tnd_ssn_hst
+FOR EACH ROW
+EXECUTE PROCEDURE f_pos_tnd_ssn_hst();
+-- Test with only B009 enabled
+SELECT 'Testing B013 in isolation...' AS test_step;
+          test_step           
+------------------------------
+ Testing B013 in isolation...
+(1 row)
+
+SELECT pglinter.disable_all_rules() AS all_disabled;
+NOTICE:  🔴 Disabled 21 rule(s)
+ all_disabled 
+--------------
+           21
+(1 row)
+
+SELECT pglinter.enable_rule('B013') AS b013_only_enabled;
+NOTICE:  ✅ Rule B013 has been enabled
+ b013_only_enabled 
+-------------------
+ t
+(1 row)
+
+SELECT pglinter.check(); -- Should only run B013
+ERROR:  set-returning functions are not allowed in WHERE
+LINE 18:         (regexp_matches(
+                  ^
+QUERY:  
+SELECT
+    COUNT(DISTINCT c.oid)::BIGINT AS tables_with_unbounded_cursor_trigger
+FROM pg_trigger tg
+JOIN pg_class     c  ON c.oid = tg.tgrelid
+JOIN pg_namespace n  ON n.oid = c.relnamespace
+JOIN pg_proc      p  ON p.oid = tg.tgfoid
+WHERE
+    NOT tg.tgisinternal
+    AND p.prolang = (SELECT oid FROM pg_language WHERE lanname = 'plpgsql')
+    AND n.nspname NOT IN (
+        'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
+    )
+    -- function body has a cursor/FOR-loop SELECT ...
+    AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
+    -- but none of those SELECT blocks contain a WHERE keyword
+    AND NOT (
+        (regexp_matches(
+            p.prosrc,
+            '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
+            'gix'
+        ))[1] ~* '\mWHERE\M'
+    )
+
+SELECT count(*) AS violation_count
+FROM pglinter.get_violations()
+WHERE rule_code = 'B013';
+ERROR:  set-returning functions are not allowed in WHERE
+LINE 18:         (regexp_matches(
+                  ^
+QUERY:  
+SELECT
+    'pg_trigger'::regclass::oid AS classid,
+    tg.oid                      AS objid,
+    0                           AS objsubid
+FROM pg_trigger    tg
+JOIN pg_class      c  ON c.oid = tg.tgrelid
+JOIN pg_namespace  n  ON n.oid = c.relnamespace
+JOIN pg_proc       p  ON p.oid = tg.tgfoid
+WHERE
+    NOT tg.tgisinternal
+    AND p.prolang = (SELECT oid FROM pg_language WHERE lanname = 'plpgsql')
+    AND n.nspname NOT IN (
+        'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
+    )
+    AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
+    AND NOT (
+        (regexp_matches(
+            p.prosrc,
+            '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
+            'gix'
+        ))[1] ~* '\mWHERE\M'
+    )
+
+-- Test with output
+SELECT pglinter.check('/tmp/pglinter_B013_results.sarif');
+ERROR:  set-returning functions are not allowed in WHERE
+LINE 18:         (regexp_matches(
+                  ^
+QUERY:  
+SELECT
+    COUNT(DISTINCT c.oid)::BIGINT AS tables_with_unbounded_cursor_trigger
+FROM pg_trigger tg
+JOIN pg_class     c  ON c.oid = tg.tgrelid
+JOIN pg_namespace n  ON n.oid = c.relnamespace
+JOIN pg_proc      p  ON p.oid = tg.tgfoid
+WHERE
+    NOT tg.tgisinternal
+    AND p.prolang = (SELECT oid FROM pg_language WHERE lanname = 'plpgsql')
+    AND n.nspname NOT IN (
+        'pg_toast', 'pg_catalog', 'information_schema', 'pglinter', '_timescaledb', 'timescaledb'
+    )
+    -- function body has a cursor/FOR-loop SELECT ...
+    AND p.prosrc ~* '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+SELECT'
+    -- but none of those SELECT blocks contain a WHERE keyword
+    AND NOT (
+        (regexp_matches(
+            p.prosrc,
+            '(?:CURSOR\s+FOR|OPEN\s+\w[\w$]*\s+FOR|FOR\s+\w[\w$]*\s+IN)\s+(SELECT\s[^;]+?)(?:;|\mLOOP\M)',
+            'gix'
+        ))[1] ~* '\mWHERE\M'
+    )
+
+-- Test if file exists and show checksum
+\! md5sum /tmp/pglinter_B013_results.sarif
+md5sum: /tmp/pglinter_B013_results.sarif: No such file or directory
+-- Cleanup
+\echo 'Cleaning up test schema...'
+Cleaning up test schema...
+DROP SCHEMA trigger_test CASCADE;
+DROP EXTENSION pglinter;

--- a/tests/expected/b013_trigger_row_by_row_with_clause.out
+++ b/tests/expected/b013_trigger_row_by_row_with_clause.out
@@ -22,6 +22,7 @@ CREATE TABLE pos_tnd_ssn_hst
     tnd_ssn_data_byte bytea,
     PRIMARY KEY (id_tnd_ssn_hst, id_ssn, id_bsn_un)
 );
+ERROR:  relation "pos_tnd_ssn_hst" already exists
 -- =============================================================================
 -- Create unique trigger functions for tables 1-5
 -- =============================================================================
@@ -30,7 +31,7 @@ LANGUAGE plpgsql
 AS
 $$
 DECLARE pos_tnd_ssn_hst_rec RECORD;
-curr CURSOR  FOR SELECT id_tnd_ssn_hst, id_ssn, ssn_status FROM pos_tnd_ssn_hst;
+curr CURSOR  FOR SELECT id_tnd_ssn_hst, id_ssn, ssn_status FROM pos_tnd_ssn_hst WHERE id_ssn = NEW.id_ssn;
 BEGIN
 	OPEN curr;
 	LOOP
@@ -43,11 +44,13 @@ BEGIN
   RETURN NEW;
 END;
 $$;
+ERROR:  function "f_pos_tnd_ssn_hst" already exists with same argument types
 CREATE TRIGGER t_pos_tnd_ssn_hst
 BEFORE INSERT OR UPDATE
 ON pos_tnd_ssn_hst
 FOR EACH ROW
 EXECUTE PROCEDURE f_pos_tnd_ssn_hst();
+ERROR:  trigger "t_pos_tnd_ssn_hst" for relation "pos_tnd_ssn_hst" already exists
 -- Test with only B009 enabled
 SELECT 'Testing B013 in isolation...' AS test_step;
           test_step           

--- a/tests/expected/c003_md5_pwd_PG17-.out
+++ b/tests/expected/c003_md5_pwd_PG17-.out
@@ -11,10 +11,10 @@ SELECT 'Testing C003 rule - MD5 password encryption checks...' AS test_info;
 
 -- First, disable all rules to isolate C003 testing
 SELECT pglinter.disable_all_rules() AS all_rules_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_rules_disabled 
 --------------------
-                 20
+                 21
 (1 row)
 
 -- Enable only C003 for focused testing

--- a/tests/expected/c003_scram_PG17-.out
+++ b/tests/expected/c003_scram_PG17-.out
@@ -114,11 +114,13 @@ SELECT '=== Test 1: C003 Rule Execution with Current Setting ===' AS test_sectio
  === Test 1: C003 Rule Execution with Current Setting ===
 (1 row)
 
-SELECT pglinter.perform_cluster_check();
-ERROR:  function pglinter.perform_cluster_check() does not exist
-LINE 1: SELECT pglinter.perform_cluster_check();
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT pglinter.check();
+NOTICE:  ✅ No issues found - database schema looks good!
+ check 
+-------
+ t
+(1 row)
+
 -- Test 2: Manual execution of C003 query
 SELECT '=== Test 2: Manual C003 Query Execution ===' AS test_section;
                 test_section                 

--- a/tests/expected/c003_scram_PG17-.out
+++ b/tests/expected/c003_scram_PG17-.out
@@ -86,10 +86,10 @@ WHERE name = 'password_encryption';
 
 -- First, disable all rules to isolate C003 testing
 SELECT pglinter.disable_all_rules() AS all_rules_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_rules_disabled 
 --------------------
-                 20
+                 21
 (1 row)
 
 -- Enable only C003 for focused testing

--- a/tests/expected/s001_schema_with_default_role_not_granted.out
+++ b/tests/expected/s001_schema_with_default_role_not_granted.out
@@ -12,10 +12,10 @@ SELECT 'Testing S001 in isolation...' AS test_step;
 (1 row)
 
 SELECT pglinter.disable_all_rules() AS all_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_disabled 
 --------------
-           20
+           21
 (1 row)
 
 SELECT pglinter.enable_rule('S001') AS S001_only_enabled;

--- a/tests/expected/s002_schema_prefixed_or_suffixed_with_envt.out
+++ b/tests/expected/s002_schema_prefixed_or_suffixed_with_envt.out
@@ -14,10 +14,10 @@ SELECT 'Testing S002 in isolation...' AS test_step;
 (1 row)
 
 SELECT pglinter.disable_all_rules() AS all_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_disabled 
 --------------
-           20
+           21
 (1 row)
 
 SELECT pglinter.enable_rule('S002') AS S002_only_enabled;

--- a/tests/expected/s003_public_schema.out
+++ b/tests/expected/s003_public_schema.out
@@ -10,10 +10,10 @@ SELECT 'S003 Regression Test: Schemas with public CREATE privileges' AS test_hea
 
 -- Setup S003 rule for testing
 SELECT pglinter.disable_all_rules();
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  disable_all_rules 
 -------------------
-                20
+                21
 (1 row)
 
 SELECT pglinter.enable_rule('S003');

--- a/tests/expected/s003_unsecured_public_schema.out
+++ b/tests/expected/s003_unsecured_public_schema.out
@@ -14,10 +14,10 @@ SELECT 'Testing S003 in isolation...' AS test_step;
 (1 row)
 
 SELECT pglinter.disable_all_rules() AS all_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_disabled 
 --------------
-           20
+           21
 (1 row)
 
 SELECT pglinter.enable_rule('S003') AS S003_only_enabled;

--- a/tests/expected/s005_several_table_owner_in_schema.out
+++ b/tests/expected/s005_several_table_owner_in_schema.out
@@ -19,10 +19,10 @@ SELECT 'Testing S005 in isolation...' AS test_step;
 (1 row)
 
 SELECT pglinter.disable_all_rules() AS all_disabled;
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  all_disabled 
 --------------
-           20
+           21
 (1 row)
 
 SELECT pglinter.enable_rule('S005') AS S005_only_enabled;

--- a/tests/expected/schema_rules.out
+++ b/tests/expected/schema_rules.out
@@ -24,10 +24,10 @@ CREATE TABLE business_logic.rules (
 );
 -- Enable only S002
 SELECT pglinter.disable_all_rules();
-NOTICE:  🔴 Disabled 20 rule(s)
+NOTICE:  🔴 Disabled 21 rule(s)
  disable_all_rules 
 -------------------
-                20
+                21
 (1 row)
 
 SELECT pglinter.enable_rule('S002');

--- a/tests/sql/b013_trigger_row_by_row.sql
+++ b/tests/sql/b013_trigger_row_by_row.sql
@@ -1,0 +1,81 @@
+CREATE EXTENSION IF NOT EXISTS pglinter;
+
+\pset pager off
+
+
+CREATE SCHEMA trigger_test;
+
+-- =============================================================================
+-- Create test tables
+-- =============================================================================
+
+-- Tables 1-5: Each will have its own unique trigger function
+CREATE TABLE pos_tnd_ssn_hst
+(
+    id_tnd_ssn_hst integer NOT NULL,
+    id_ssn varchar(32) NOT NULL,
+    id_bsn_un varchar(32) NOT NULL,
+    id_ws varchar(32),
+    id_opr varchar(64),
+    id_safe integer,
+    id_till integer,
+    ts_ssn timestamp,
+    ssn_status varchar(32) NOT NULL,
+    ty_ssn varchar(32),
+    tnd_ssn_data text,
+    ssn_performed_by varchar(64) NOT NULL,
+    tnd_ssn_data_byte bytea,
+    PRIMARY KEY (id_tnd_ssn_hst, id_ssn, id_bsn_un)
+);
+
+-- =============================================================================
+-- Create unique trigger functions for tables 1-5
+-- =============================================================================
+
+CREATE FUNCTION f_pos_tnd_ssn_hst() RETURNS trigger
+LANGUAGE plpgsql
+AS
+$$
+DECLARE pos_tnd_ssn_hst_rec RECORD;
+curr CURSOR  FOR SELECT id_tnd_ssn_hst, id_ssn, ssn_status FROM pos_tnd_ssn_hst;
+BEGIN
+	OPEN curr;
+	LOOP
+		FETCH curr INTO pos_tnd_ssn_hst_rec;
+			IF NEW.id_ssn = pos_tnd_ssn_hst_rec.id_ssn AND NEW.ssn_status = pos_tnd_ssn_hst_rec.ssn_status AND NEW.ssn_status <> 'Redeclared' THEN
+			RAISE EXCEPTION 'Invalid Status';
+		END IF;
+    EXIT WHEN NOT FOUND;
+	END LOOP;
+  RETURN NEW;
+END;
+$$;
+
+
+CREATE TRIGGER t_pos_tnd_ssn_hst
+BEFORE INSERT OR UPDATE
+ON pos_tnd_ssn_hst
+FOR EACH ROW
+EXECUTE PROCEDURE f_pos_tnd_ssn_hst();
+
+
+-- Test with only B009 enabled
+SELECT 'Testing B013 in isolation...' AS test_step;
+SELECT pglinter.disable_all_rules() AS all_disabled;
+SELECT pglinter.enable_rule('B013') AS b013_only_enabled;
+SELECT pglinter.check(); -- Should only run B013
+
+SELECT count(*) AS violation_count
+FROM pglinter.get_violations()
+WHERE rule_code = 'B013';
+
+-- Test with output
+SELECT pglinter.check('/tmp/pglinter_B013_results.sarif');
+-- Test if file exists and show checksum
+\! md5sum /tmp/pglinter_B013_results.sarif
+
+-- Cleanup
+\echo 'Cleaning up test schema...'
+DROP SCHEMA trigger_test CASCADE;
+
+DROP EXTENSION pglinter;

--- a/tests/sql/b013_trigger_row_by_row_with_clause.sql
+++ b/tests/sql/b013_trigger_row_by_row_with_clause.sql
@@ -1,9 +1,14 @@
 CREATE EXTENSION IF NOT EXISTS pglinter;
+
 \pset pager off
+
+
 CREATE SCHEMA trigger_test;
+
 -- =============================================================================
 -- Create test tables
 -- =============================================================================
+
 -- Tables 1-5: Each will have its own unique trigger function
 CREATE TABLE pos_tnd_ssn_hst
 (
@@ -22,15 +27,17 @@ CREATE TABLE pos_tnd_ssn_hst
     tnd_ssn_data_byte bytea,
     PRIMARY KEY (id_tnd_ssn_hst, id_ssn, id_bsn_un)
 );
+
 -- =============================================================================
 -- Create unique trigger functions for tables 1-5
 -- =============================================================================
+
 CREATE FUNCTION f_pos_tnd_ssn_hst() RETURNS trigger
 LANGUAGE plpgsql
 AS
 $$
 DECLARE pos_tnd_ssn_hst_rec RECORD;
-curr CURSOR  FOR SELECT id_tnd_ssn_hst, id_ssn, ssn_status FROM pos_tnd_ssn_hst;
+curr CURSOR  FOR SELECT id_tnd_ssn_hst, id_ssn, ssn_status FROM pos_tnd_ssn_hst WHERE id_ssn = NEW.id_ssn;
 BEGIN
 	OPEN curr;
 	LOOP
@@ -43,66 +50,32 @@ BEGIN
   RETURN NEW;
 END;
 $$;
+
+
 CREATE TRIGGER t_pos_tnd_ssn_hst
 BEFORE INSERT OR UPDATE
 ON pos_tnd_ssn_hst
 FOR EACH ROW
 EXECUTE PROCEDURE f_pos_tnd_ssn_hst();
+
+
 -- Test with only B009 enabled
 SELECT 'Testing B013 in isolation...' AS test_step;
-          test_step           
-------------------------------
- Testing B013 in isolation...
-(1 row)
-
 SELECT pglinter.disable_all_rules() AS all_disabled;
-NOTICE:  🔴 Disabled 21 rule(s)
- all_disabled 
---------------
-           21
-(1 row)
-
 SELECT pglinter.enable_rule('B013') AS b013_only_enabled;
-NOTICE:  ✅ Rule B013 has been enabled
- b013_only_enabled 
--------------------
- t
-(1 row)
-
 SELECT pglinter.check(); -- Should only run B013
-NOTICE:  🔍 pglinter found 1 issue(s):
-NOTICE:  ==================================================
-NOTICE:  ❌ [B013] ERROR: 1/1 table(s) using row by row processing without any where clause exceed the error threshold: 100%. Object list:
-public.pos_tnd_ssn_hst.t_pos_tnd_ssn_hst -> public.f_pos_tnd_ssn_hst
-
-NOTICE:  ==================================================
-NOTICE:  📊 Summary: 1 error(s), 0 warning(s), 0 info
-NOTICE:  🔴 Critical issues found - please review and fix errors
- check 
--------
- t
-(1 row)
 
 SELECT count(*) AS violation_count
 FROM pglinter.get_violations()
 WHERE rule_code = 'B013';
- violation_count 
------------------
-               1
-(1 row)
 
 -- Test with output
 SELECT pglinter.check('/tmp/pglinter_B013_results.sarif');
- check 
--------
- t
-(1 row)
-
 -- Test if file exists and show checksum
 \! md5sum /tmp/pglinter_B013_results.sarif
-ed1b2a0d0091a61d7d6f87dedd4c3877  /tmp/pglinter_B013_results.sarif
+
 -- Cleanup
 \echo 'Cleaning up test schema...'
-Cleaning up test schema...
 DROP SCHEMA trigger_test CASCADE;
+
 DROP EXTENSION pglinter;

--- a/tests/sql/c003_scram_PG17-.sql
+++ b/tests/sql/c003_scram_PG17-.sql
@@ -78,7 +78,7 @@ SELECT pglinter.is_rule_enabled('C003') AS c003_status;
 
 -- Test 1: Check if C003 detects any issues with current setting
 SELECT '=== Test 1: C003 Rule Execution with Current Setting ===' AS test_section;
-SELECT pglinter.perform_cluster_check();
+SELECT pglinter.check();
 
 -- Test 2: Manual execution of C003 query
 SELECT '=== Test 2: Manual C003 Query Execution ===' AS test_section;


### PR DESCRIPTION
Fixes #91 

This pull request introduces a new rule (B013) to detect row-by-row trigger functions in PostgreSQL that use a cursor or FOR-loop without a WHERE clause, which can cause severe performance issues. It updates the documentation, SQL rules, and test cases to support this new rule, and increments the package version. The most important changes are grouped below:

New Rule Addition: Trigger Functions With Unbounded Cursor

* Added rule B013 (`HowManyTablesWithRowByRowTriggerWithoutWhereClause`) to the rules table, including severity thresholds, description, message template, and remediation advice in `sql/rules.sql`.
* Implemented SQL queries for B013 to identify triggers using row-by-row processing without a WHERE clause, list affected objects, and provide violation details in `sql/rules.sql`.
* Added rule message for B013 to `pglinter.rule_messages` for user-facing warnings and advice in `sql/rules.sql`.
* Documented B013 in `docs/rules/README.md` with explanation, rationale, and SQL examples.

Test Suite and Version Updates

* Updated test outputs to reflect the new rule count (21 rules) and added regression test for B013 in `Makefile` and multiple `tests/expected/*.out` files. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R60) [[2]](diffhunk://#diff-0e3b2f76afe8769f4bcec226305f6792d9483a9df23e0540c4ef2ddc19c2bb39L15-R18) [[3]](diffhunk://#diff-a966a6ab72fe8830d97f4a219db83ced3c74edadb56b7a5b9b6ab5db758c7dc2L18-R21) [[4]](diffhunk://#diff-8e484f0d6c9c7ec937280a673ef9abe6265dd15ac1f88c3dc16bd79d5eee8a0fL135-R138) [[5]](diffhunk://#diff-0a09ee02c1a7c82e4d3a889cd1a96d3ff901ad772340f63e159038f67cac4e60L29-R32) [[6]](diffhunk://#diff-807ebb98563c57b193a29ff9912c2fa95ac1f57e00b554db6fb617c88ae38c5cL52-R55) [[7]](diffhunk://#diff-6c752335d19037f1dfc484dde02d84575741b199d63e7d9ad00cb9bc1118f6d6L112-R115) [[8]](diffhunk://#diff-49cf3099799e520fb9fc89ee439e3fd6d4ba9d28f126f28e18071e15c71f667fL81-R84)
* Incremented package version from 1.1.1 to 1.1.2 in `Cargo.toml`.

Test Output Impact

* Test output for `b007_fk_outside_schema` now shows errors due to the use of set-returning functions in WHERE clauses, which is related to the new B013 rule's SQL implementation. [[1]](diffhunk://#diff-4d7741a5910d2d954140ebdbbcbfeefd6380ac7f824b3311c82f10f3c9048a76L160-R213) [[2]](diffhunk://#diff-4d7741a5910d2d954140ebdbbcbfeefd6380ac7f824b3311c82f10f3c9048a76L256-R318)