### PR TITLE
fix(ci): new 0.18.0 pgrx version

### DIFF
--- a/.github/actions/reusable-package-action/action.yml
+++ b/.github/actions/reusable-package-action/action.yml
@@ -1,21 +1,22 @@
 # .github/actions/reusable-package-action/action.yml
-name: 'Build package and upload'
+name: "Build package and upload"
 
-description: 'Builds rpm/deb package and upload.'
+description: "Builds rpm/deb package and upload."
 
 inputs:
   pgver:
-    description: 'The PostgreSQL major version with the "pg" prefix (e.g. `pg13`, `pg16`, etc.)'
+    description: "The PostgreSQL major version with the \"pg\" prefix (e.g. `pg13`,
+      `pg16`, etc.)"
     required: true
   tag:
     description: "The tag version"
     required: true
   arch:
-    description: 'Target architecture (amd64 or arm64)'
+    description: "Target architecture (amd64 or arm64)"
     required: false
     default: amd64
   pkgtype:
-    description: 'Package type to build (rpm or deb)'
+    description: "Package type to build (rpm or deb)"
     required: true
     default: deb
 
@@ -55,6 +56,28 @@ runs:
         echo "PG_VERSION=$(echo '${{ inputs.pgver }}' | sed 's/^pg//')" >> $GITHUB_ENV
       shell: bash
 
+    - name: Ensure matching cargo-pgrx version
+      run: |
+        set -euo pipefail
+        PGRX_VERSION="$(sed -nE 's/^pgrx = "([^"]+)"/\1/p' "$GITHUB_WORKSPACE/Cargo.toml" | head -n1)"
+        if [ -z "$PGRX_VERSION" ]; then
+          echo "Could not determine pgrx version from Cargo.toml"
+          exit 1
+        fi
+
+        su - postgres -c "PGRX_VERSION='$PGRX_VERSION' bash -lc '
+          set -euo pipefail
+          installed_version=\$(cargo pgrx --version 2>/dev/null | grep -Eo \"[0-9]+\\.[0-9]+\\.[0-9]+\" | head -n1 || true)
+          if [ \"\$installed_version\" != \"\$PGRX_VERSION\" ]; then
+            cargo install --locked --version \"\$PGRX_VERSION\" cargo-pgrx
+          fi
+          if [ ! -f \"\$HOME/.pgrx/config.toml\" ]; then
+            cargo pgrx init
+          fi
+          cargo pgrx --version
+        '"
+      shell: bash
+
     - name: Build selected package
       run: |
         export PACKAGE_ARCH=${{ inputs.arch }}
@@ -68,16 +91,17 @@ runs:
         fi
       shell: bash
 
-    - name: 'RPM package for ${{ inputs.pgver }} (${{ inputs.arch }})'
+    - name: "RPM package for ${{ inputs.pgver }} (${{ inputs.arch }})"
       if: ${{ inputs.pkgtype == 'rpm' }}
       uses: actions/upload-artifact@v4
       with:
-        name: postgresql_pglinter_${{ env.PG_VERSION }}-${{ env.PGLINTER_MINOR_VERSION }}-1.${{ env.RPM_ARCH }}.rpm
+        name: postgresql_pglinter_${{ env.PG_VERSION }}-${{ env.PGLINTER_MINOR_VERSION
+          }}-1.${{ env.RPM_ARCH }}.rpm
         path: target/release/pglinter-${{ inputs.pgver }}/*.rpm
 
-    - name: 'DEB package for ${{ inputs.pgver }} (${{ inputs.arch }})'
+    - name: "DEB package for ${{ inputs.pgver }} (${{ inputs.arch }})"
       if: ${{ inputs.pkgtype == 'deb' }}
       uses: actions/upload-artifact@v4
       with:
-        name: postgresql_pglinter_${{ env.PG_VERSION }}-${{ env.PGLINTER_MINOR_VERSION }}_${{ env.DEB_ARCH }}.deb
+        name: postgresql_pglinter_${{ env.PG_VERSION }}-${{ env.PGLINTER_MINOR_VERSION}}_${{ env.DEB_ARCH }}.deb
         path: target/release/pglinter-${{ inputs.pgver }}/*.deb

--- a/Makefile
+++ b/Makefile
@@ -411,9 +411,9 @@ OCI_TAG?=$(OCI_BASE_TAG)-$(PG_VERSION_OCI)-$(DISTRO)
 # Ensure buildx is available for OCI builds
 oci_setup:
 	@echo "Setting up Docker buildx for multi-platform builds..."
-	@sudo docker buildx create --name pglinter-oci-builder --use --bootstrap 2>/dev/null || \
-	sudo docker buildx use pglinter-oci-builder 2>/dev/null || \
-	(echo "Creating new buildx instance..." && sudo docker buildx create --name pglinter-oci-builder --use --bootstrap)
+	@docker buildx create --name pglinter-oci-builder --use --bootstrap 2>/dev/null || \
+	docker buildx use pglinter-oci-builder 2>/dev/null || \
+	(echo "Creating new buildx instance..." && docker buildx create --name pglinter-oci-builder --use --bootstrap)
 
 
 # Build OCI extension image for AMD64 platform only (can be loaded locally)
@@ -422,7 +422,7 @@ oci_image: oci_setup
 	@echo "  PostgreSQL Version: $(PG_VERSION_OCI)"
 	@echo "  Extension Version: $(PGLINTER_MINOR_VERSION)"
 	@echo "  Distro: $(DISTRO)"
-	sudo docker buildx build \
+	docker buildx build \
 		--platform linux/amd64,linux/arm64 \
 		--build-arg PG_VERSION=$(PG_VERSION_OCI) \
 		--build-arg DISTRO=$(DISTRO) \


### PR DESCRIPTION
This pull request primarily updates the GitHub Actions workflow and the `Makefile` to improve consistency, automation, and usability in the build and packaging process. The most significant changes include ensuring the correct `cargo-pgrx` version is used during package builds, removing unnecessary use of `sudo` for Docker commands, and improving YAML formatting for clarity.

**CI/CD improvements:**

* Added a step in `.github/actions/reusable-package-action/action.yml` to ensure the installed `cargo-pgrx` version matches the version specified in `Cargo.toml`, installing or initializing it as needed. This prevents version mismatches during package builds.
* Improved YAML formatting in `.github/actions/reusable-package-action/action.yml` for better readability and consistency, including quoting and line wrapping for descriptions and names. [[1]](diffhunk://#diff-4dcede651fcb7bcd35e52861eff1069fa3713c0cd311edb00c8a205a68848048L2-R19) [[2]](diffhunk://#diff-4dcede651fcb7bcd35e52861eff1069fa3713c0cd311edb00c8a205a68848048L71-R102)

**Build system improvements:**

* Removed unnecessary use of `sudo` from Docker commands in the `Makefile`, simplifying the build process and reducing permission issues for users running builds locally. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L414-R416) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L425-R425)