### PR TITLE
fix(ci): 2.0.0

### DIFF
--- a/.github/actions/build-oci-make/action.yml
+++ b/.github/actions/build-oci-make/action.yml
@@ -1,20 +1,20 @@
-name: 'Build OCI Image (Make)'
-description: 'Builds OCI image using make oci_image.'
+name: "Build OCI Image (Make)"
+description: "Builds OCI image using make oci_image."
 inputs:
   distro:
-    description: 'Target distribution (e.g., bookworm, trixie)'
+    description: "Target distribution (e.g., bookworm, trixie)"
     required: false
   ocipgversion:
-    description: 'PostgreSQL version (e.g., pg18)'
+    description: "PostgreSQL version (e.g., pg18)"
     required: false
   github-token:
-    description: 'GitHub token for authentication'
+    description: "GitHub token for authentication"
     required: true
   oci-tag:
-    description: 'image tag'
+    description: "image tag"
     required: false
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     # - name: Login to GitHub Container Registry
     #   uses: docker/login-action@v3.0.0
@@ -23,7 +23,8 @@ runs:
     #     username: pmpetit
     #     password: ${{ inputs.github_token }}
     - name: Log in to GitHub Container Registry
-      run: echo "${{ inputs.github_token }}" | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      run: echo "${{ inputs.github_token }}" | docker login ghcr.io -u ${{
+        github.actor }} --password-stdin
       shell: bash
     - name: Build OCI image
       run: |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,13 +212,7 @@ mod pglinter {
         }
     }
 
-    #[pg_extern(sql = "
-        CREATE FUNCTION pglinter.get_violations()
-        RETURNS TABLE(rule_code TEXT, classid OID, objid OID, objsubid INTEGER, message TEXT)
-        AS 'MODULE_PATHNAME', 'get_violations_wrapper'
-        LANGUAGE C
-        SECURITY DEFINER;
-    ")]
+    #[pg_extern(security_definer)]
     fn get_violations() -> TableIterator<
         'static,
         (


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the packaging, build, and CI workflows, with a focus on better support for ARM64 builds, improved Docker image handling, and general modernization of the automation scripts. The most notable changes include adding a custom release profile for ARM64 builds to avoid out-of-memory issues, updating Docker and packaging scripts to remove unnecessary `sudo` usage, and refining the handling of build artifacts and environment variables.

**Build and packaging improvements:**

* Added a new `[profile.release-lto-off]` profile in `Cargo.toml` for ARM64 builds, which disables LTO and increases codegen units to prevent out-of-memory errors on CI runners.
* Updated `.github/actions/reusable-package-action/action.yml` to set `PACKAGE_PROFILE` and `PGRX_PACKAGE_FLAGS` based on architecture, ensuring ARM64 builds use the correct profile and flags. [[1]](diffhunk://#diff-4dcede651fcb7bcd35e52861eff1069fa3713c0cd311edb00c8a205a68848048R46-R59) [[2]](diffhunk://#diff-4dcede651fcb7bcd35e52861eff1069fa3713c0cd311edb00c8a205a68848048R90-R98)
* Modified artifact upload paths in `.github/actions/reusable-package-action/action.yml` to use architecture-specific target directories, aligning with the new build profiles.
* Updated the `Makefile` to pass `PGRX_PACKAGE_FLAGS` to the `pgrx package` command and to use the correct Docker image tags and build arguments for both AMD64 and ARM64 builds. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R278-R286) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L297-R299)

**Docker and CI workflow modernization:**

* Removed unnecessary `sudo` from Docker commands in the `Makefile`, making local and CI builds more consistent and less privileged. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L332-R336) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L345-R349) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L360-R376) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L394-R397)
* Updated Dockerfiles and workflow defaults to use PostgreSQL 14 as the baseline version instead of 13, reflecting current support targets. [[1]](diffhunk://#diff-6a00c4cf3022661a97ffdb93b61c251e561417f4975aba2efe32b1ef1cba2df7L2-R6) [[2]](diffhunk://#diff-7b159399a89f16322d38510dae5ff3085f66127e6af67302c311aa380992c4a8L4-R4) [[3]](diffhunk://#diff-e95d819aac0cb38407107744aea883a4e4c6cce99fa4b1d7e33b1aeb1784b366L28-R28)
* Changed the container image tag used in `.github/workflows/package-and-deploy.yml` to `latest-<arch>` for more predictable CI builds.

**General cleanup and minor fixes:**

* Updated YAML files to use consistent double-quoted strings for better readability and YAML compliance.
* Fixed example PostgreSQL version in `reusable-package-action/action.yml` from `pg13` to `pg14` to match supported versions.
* Commented out certain regression tests in the `Makefile` for stability or pending investigation.
* Updated the `get_violations` function in `src/lib.rs` to use the `security_definer` attribute instead of inline SQL, modernizing the code.

These changes collectively improve the reliability, maintainability, and cross-platform support of the build and packaging process.