### PR TITLE
fix(ci): typo

### DIFF
--- a/.github/actions/build-oci-make/action.yml
+++ b/.github/actions/build-oci-make/action.yml
@@ -23,7 +23,7 @@ runs:
     #     username: pmpetit
     #     password: ${{ inputs.github_token }}
     - name: Log in to GitHub Container Registry
-      run: echo "${{ inputs.github_token }}" | docker login ghcr.io -u ${{
+      run: echo "${{ inputs.github-token }}" | docker login ghcr.io -u ${{
         github.actor }} --password-stdin
       shell: bash
     - name: Build OCI image
@@ -31,7 +31,7 @@ runs:
         export DISTRO="${{ inputs.distro || 'bookworm' }}"
         export OCIPGVERSION="${{ inputs.ocipgversion }}"
         export PG_VERSION_OCI="${OCIPGVERSION#pg}"
-        export GITHUB_TOKEN="${{ inputs.github_token }}"
+        export GITHUB_TOKEN="${{ inputs.github-token }}"
         if [ -n "${{ inputs.oci-tag }}" ]; then
           export OCI_TAG="${{ inputs.oci-tag }}"
         fi

--- a/.github/actions/build-oci-test/action.yml
+++ b/.github/actions/build-oci-test/action.yml
@@ -17,7 +17,8 @@ runs:
   using: "composite"
   steps:
     - name: Login to GitHub Container Registry
-      run: echo "${{ inputs.github_token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      run: echo "${{ inputs.github-token }}" | docker login ghcr.io -u ${{
+        github.actor }} --password-stdin
       shell: bash
     - name: Test OCI image
       run: |

--- a/.github/actions/reusable-package-action/action.yml
+++ b/.github/actions/reusable-package-action/action.yml
@@ -106,14 +106,12 @@ runs:
       if: ${{ inputs.pkgtype == 'rpm' }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: postgresql_pglinter_${{ env.PG_VERSION
-          }}-${{env.PGLINTER_MINOR_VERSION}}-1.${{ env.RPM_ARCH }}.rpm
+        name: postgresql_pglinter_${{env.PG_VERSION}}-${{env.PGLINTER_MINOR_VERSION}}-1.${{ env.RPM_ARCH}}.rpm
         path: target/${{ env.PACKAGE_PROFILE }}/pglinter-${{ inputs.pgver }}/*.rpm
 
     - name: "DEB package for ${{ inputs.pgver }} (${{ inputs.arch }})"
       if: ${{ inputs.pkgtype == 'deb' }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: postgresql_pglinter_${{ env.PG_VERSION
-          }}-${{env.PGLINTER_MINOR_VERSION}}_${{ env.DEB_ARCH }}.deb
+        name: postgresql_pglinter_${{env.PG_VERSION}}-${{env.PGLINTER_MINOR_VERSION}}_${{ env.DEB_ARCH}}.deb
         path: target/${{ env.PACKAGE_PROFILE }}/pglinter-${{ inputs.pgver }}/*.deb


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to improve consistency in variable naming and fix minor formatting issues. The most important changes include standardizing input variable names and correcting artifact naming in upload steps.

**Variable naming consistency:**

* Updated all references from `inputs.github_token` to `inputs.github-token` in the `build-oci-make` and `build-oci-test` action workflows to match the expected input parameter name. [[1]](diffhunk://#diff-2697b718ab090804129aba6b55338e3025093e1df3ac9659d1f9ccd6f0977970L26-R34) [[2]](diffhunk://#diff-722cf22332baa9dea8c2e2732a818f455b1fd98bd7540570e1590323ace8c9c5L20-R21)

**Artifact naming and formatting:**

* Fixed formatting issues in artifact names by removing unnecessary line breaks and spaces in the `reusable-package-action` workflow, ensuring artifact names are constructed correctly for both RPM and DEB packages.